### PR TITLE
[Rahul] | Add. Exception Handling Logic In TranscriptionsController

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem "devise", "~> 4.9"
 # Tailwind CSS
 gem "tailwindcss-rails", "~> 2.7"
 # CORS for API
-gem 'rack-cors', "~> 2.0.1"
+gem "rack-cors", "~> 2.0.1"
 
 
 

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,6 +1,6 @@
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins '*'
-    resource '*', headers: :any, methods: [:get, :post, :patch, :put]
+    origins "*"
+    resource "*", headers: :any, methods: [ :get, :post, :patch, :put ]
   end
 end


### PR DESCRIPTION
This PR introduces several improvements to the Api::V1::TranscriptionsController in the following areas:
1. Wrapped the transcription `create` and `generate_completion` logic in `begin-rescue` blocks to catch and handle errors gracefully.
2. Added a rescue clause for `StandardError` in both `create` and `generate_completion` methods to log errors and return a user-friendly message.
3. Updated the logic to ensure that the transcription status is updated correctly upon errors and successful completions.