### PR TITLE
Add. Optional MinIO Service for File Storage

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -29,7 +29,7 @@ Rails.application.configure do
   config.cache_store = :memory_store
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  config.active_storage.service = ENV.fetch("STORAGE_SERVICE", "local")
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -22,7 +22,7 @@ Rails.application.configure do
   # config.asset_host = "http://assets.example.com"
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :amazon
+  config.active_storage.service = ENV.fetch("STORAGE_SERVICE", "local")
 
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.
   config.assume_ssl = true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -29,7 +29,7 @@ Rails.application.configure do
   config.action_controller.allow_forgery_protection = false
 
   # Store uploaded files on the local file system in a temporary directory.
-  config.active_storage.service = :test
+  config.active_storage.service = ENV.fetch("STORAGE_SERVICE", "local")
 
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -13,6 +13,17 @@ amazon:
   secret_access_key: <%= ENV.fetch('AWS_SECRET_ACCESS_KEY') %>
   region: <%= ENV.fetch('AWS_REGION') %>
   bucket: <%= ENV.fetch('AWS_BUCKET') %>
+
+# Use bin/rails credentials:edit to set the MinIO secrets (as minio:access_key_id|secret_access_key)
+minio:
+  service: S3
+  bucket: <%= ENV.fetch('MINIO_BUCKET') || 'application' %>
+  endpoint: <%= ENV.fetch('MINIO_ENDPOINT') || 'https://localhost:9000' %>
+  access_key_id: <%= ENV.fetch('MINIO_ACCESS_KEY_ID') || 'minioadmin' %>
+  secret_access_key: <%= ENV.fetch('MINIO_SECRET_ACCESS_KEY') || 'minioadmin' %>
+  region: <%= ENV.fetch('MINIO_REGION') || 'us-east-1' %>
+  force_path_style: true
+
 # Remember not to checkin your GCS keyfile to a repository
 # google:
 #   service: GCS

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,11 @@ services:
       AWS_REGION: ${AWS_REGION}
       AWS_BUCKET: ${AWS_BUCKET}
       PLUGIN_BASE_URL: ${PLUGIN_BASE_URL}
+      MINIO_BUCKET: ${MINIO_BUCKET}
+      MINIO_ACCESS_KEY_ID: ${MINIO_ACCESS_KEY_ID}
+      MINIO_SECRET_ACCESS_KEY: ${MINIO_SECRET_ACCESS_KEY}
+      MINIO_ENDPOINT: ${MINIO_ENDPOINT}
+      MINIO_REGION: ${MINIO_REGION}
     volumes:
       - .:/app:cached
     ports:
@@ -49,6 +54,22 @@ services:
       medispeak_db:
         condition: service_healthy
     restart: unless-stopped
+
+  minio:
+    profiles:
+    - "minio"
+    image: bitnami/minio
+    ports:
+    - '9000:9000'
+    - '9001:9001'
+    volumes:
+    - 'minio:/bitnami/minio/data'
+    environment:
+    - MINIO_ROOT_USER=minioadmin
+    - MINIO_ROOT_PASSWORD=minioadmin
+    - MINIO_DEFAULT_BUCKETS=application
 volumes:
   medispeak_data:
+    driver: local
+  minio:
     driver: local

--- a/docs/docker_setup_guide.md
+++ b/docs/docker_setup_guide.md
@@ -200,6 +200,49 @@ For production deployments, ensure the following:
 
 ---
 
+## 7. Optional MinIO Setup for File Storage
+
+In addition to using AWS S3 for file storage, Medispeak can be configured to use MinIO as an alternative. MinIO is an open-source object storage service that is fully compatible with the AWS S3 API. This section will guide you through setting up MinIO as the file storage service for the Medispeak backend using Docker Compose.
+
+### 7.1 Environment Variables for MinIO
+
+To configure MinIO as the file storage service, you'll need to update your `.env` file with the following environment variables:
+
+```bash
+# MinIO credentials for file storage (required only for production)
+# These are needed to configure Active Storage with MinIO, an S3-compatible object storage service.
+MINIO_ACCESS_KEY_ID=your_minio_access_key_id
+MINIO_SECRET_ACCESS_KEY=your_minio_secret_access_key
+MINIO_ENDPOINT=https://your_minio_endpoint.com
+MINIO_BUCKET=your_minio_bucket_name
+MINIO_REGION=your_minio_region
+```
+
+> **Note**: Replace `your_minio_access_key_id`, `your_minio_secret_access_key`, and `your_minio_bucket_name` with the actual credentials for your MinIO instance. The `MINIO_ENDPOINT` should point to the local MinIO service running on port 9000.
+
+### 7.2 Switching Between AWS and MinIO
+
+You can switch between AWS and MinIO by modifying the `STORAGE_SERVICE` environment variable in the `.env` file:
+
+```bash
+# Default Storage Service
+STORAGE_SERVICE=minio # Set to 'amazon' for AWS S3 or 'local' for local storage
+```
+
+When `STORAGE_SERVICE=minio`, the application will use MinIO for file storage. If you'd like to switch back to AWS S3, simply change the value to `amazon`.
+
+### 7.3 Running the Application with MinIO
+
+After configuring MinIO, you can bring up the services, including the MinIO service, by running:
+
+```bash
+docker-compose --profile minio up -d
+```
+
+> **Note**: The `--profile minio` flag ensures that the MinIO service is only brought up when needed, and the environment variables are properly set.
+
+---
+
 ## Conclusion
 
 By following this guide, you can get the Medispeak backend and its PostgreSQL database up and running using Docker Compose. The environment is flexible, allowing you to adjust configurations via environment variables and scale for both development and production needs.

--- a/example.env
+++ b/example.env
@@ -1,3 +1,6 @@
+# Docker Compose Variables (e.g., minio)
+COMPOSE_PROFILES=
+
 # Credentials for using Open AI
 OPENAI_ACCESS_TOKEN=token_from_open_ai
 OPENAI_ORGANIZATION_ID=org_id_for_open_ai
@@ -5,22 +8,33 @@ OPENAI_ORGANIZATION_ID=org_id_for_open_ai
 # Base URL for pulling the plugin
 PLUGIN_BASE_URL=https://medispeak-app.pages.dev
 
-# Rails Environment Variables
-RAILS_ENV=
-BUNDLE_DEPLOYMENT=
-BUNDLE_PATH=
-BUNDLE_WITHOUT=
-RAILS_MASTER_KEY=
-BACKEND_PORT=
+# Essential configuration variables for running the Rails application.
+RAILS_ENV= # The environment in which the app is running (e.g., development, production)
+BUNDLE_DEPLOYMENT= # Ensures gems are only installed via bundle in deployment mode
+BUNDLE_PATH= # Path where bundled gems are installed
+BUNDLE_WITHOUT= # Exclude certain groups when installing gems
+RAILS_MASTER_KEY= # The key used for decrypting Rails credentials
+BACKEND_PORT= # Port where the Rails backend will be running
 
-# AWS credentials for file storage, required only for production
-# https://guides.rubyonrails.org/active_storage_overview.html
-AWS_ACCESS_KEY_ID=AWS_ACCESS_KEY_ID
-AWS_SECRET_ACCESS_KEY=AWS_SECRET_ACCESS_KEY
-AWS_REGION=AWS_REGION
-AWS_BUCKET=AWS_BUCKET
+# Default Storage Service
+STORAGE_SERVICE= # This specifies the storage service to be used (minio, amazon, local, etc.).
 
-# Database Configuration (Required)
+# AWS credentials for file storage (required only for production)
+# These variables are used to configure Active Storage with AWS S3 for file storage in production.
+AWS_ACCESS_KEY_ID=your_aws_access_key_id
+AWS_SECRET_ACCESS_KEY=your_aws_secret_access_key
+AWS_REGION=your_aws_region
+AWS_BUCKET=your_aws_s3_bucket_name
+
+# MinIO credentials for file storage (required only for production)
+# These are needed to configure Active Storage with MinIO, an S3-compatible object storage service.
+MINIO_ACCESS_KEY_ID=your_minio_access_key_id
+MINIO_SECRET_ACCESS_KEY=your_minio_secret_access_key
+MINIO_ENDPOINT=https://your_minio_endpoint.com
+MINIO_BUCKET=your_minio_bucket_name
+MINIO_REGION=your_minio_region
+
+# Essential for configuring the PostgreSQL database connection for the Rails app.
 POSTGRES_IMAGE_TAG=14.2-alpine
 DB_NAME=medispeak
 DB_NAME_TEST=medispeak_test


### PR DESCRIPTION
This PR introduces an optional **MinIO** service to the Docker Compose setup for the Medispeak backend. MinIO provides an alternative to AWS S3 for file storage, while maintaining compatibility with the S3 API. This update includes the necessary environment variables and configuration changes to enable seamless switching between MinIO and AWS S3.

#### Changes:
- Added **MinIO** service to `docker-compose.yml` under the `minio` profile.
- Introduced **environment variables** for MinIO configuration in the `.env` file.
- Updated the **Rails `storage.yml`** configuration to support MinIO as an S3-compatible storage option.
- Added a new `STORAGE_SERVICE` environment variable to toggle between storage providers (`minio`, `amazon`, `local`).

#### Usage:
To enable the MinIO service, run the following command:
```bash
docker-compose --profile minio up -d
```
Ensure the relevant environment variables are set for MinIO in the `.env` file.

#### Notes:
- MinIO is intended as an alternative to AWS S3, particularly for local or non-AWS deployments.
- The MinIO service runs on port 9000 for API access and port 9001 for the management console (optional).

#### Issue Reference:
This PR addresses [Issue #39](https://github.com/medispeak/backend/issues/39) raised in the Medispeak backend repository.