### PR TITLE
Add. Missing STORAGE_SERVICE Env And Default Minio Endpoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,7 @@ services:
       MINIO_SECRET_ACCESS_KEY: ${MINIO_SECRET_ACCESS_KEY}
       MINIO_ENDPOINT: ${MINIO_ENDPOINT}
       MINIO_REGION: ${MINIO_REGION}
+      STORAGE_SERVICE: ${STORAGE_SERVICE}
     volumes:
       - .:/app:cached
     ports:

--- a/docs/docker_setup_guide.md
+++ b/docs/docker_setup_guide.md
@@ -218,7 +218,7 @@ MINIO_BUCKET=your_minio_bucket_name
 MINIO_REGION=your_minio_region
 ```
 
-> **Note**: Replace `your_minio_access_key_id`, `your_minio_secret_access_key`, and `your_minio_bucket_name` with the actual credentials for your MinIO instance. The `MINIO_ENDPOINT` should point to the local MinIO service running on port 9000.
+> **Note**: Replace `your_minio_access_key_id`, `your_minio_secret_access_key`, and `your_minio_bucket_name` with the actual credentials for your MinIO instance. The `MINIO_ENDPOINT` should point to the local MinIO service running on port [9000](https://localhost:9000).
 
 ### 7.2 Switching Between AWS and MinIO
 


### PR DESCRIPTION
This PR adds the missing STORAGE_SERVICE environment variable to improve configurability for the storage service. Additionally, it adds the default endpoint for MinIO to the Developer Guide streamlining setup and ensuring that the system can connect seamlessly to MinIO as the default storage solution. 