### PR TITLE
fix: harden the OCR pipeline, document it, and make it testable from the playground

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -331,8 +331,25 @@ button[disabled]        .when-enabled { display: none; }
   .pg-orb-recording { @apply bg-rose-600 hover:bg-rose-500; }
   .pg-orb-busy      { @apply bg-blue-600; }
 
+  /* Source switch. A segmented control rather than tabs with panels: the two
+     modes share one card, one status line and one result, so a control that
+     implied separate screens would misdescribe the page. */
+  .pg-modes { @apply inline-flex items-center gap-1 rounded-xl bg-gray-100 p-1; }
+  .pg-mode {
+    @apply rounded-lg px-3 py-1.5 text-sm font-medium text-gray-600;
+
+    transition: ease 0.15s background-color, ease 0.15s color;
+  }
+  .pg-mode:not(:disabled):hover { @apply cursor-pointer text-gray-900; }
+  .pg-mode:disabled { @apply cursor-default opacity-50; }
+  .pg-mode:focus-visible { @apply outline-none ring-2 ring-blue-500 ring-offset-2; }
+  .pg-mode-on { @apply bg-white text-gray-900 shadow-sm; }
+
   .pg-icon { @apply hidden h-6 w-6; }
   .pg-orb-idle .pg-icon-mic { @apply block; }
+  /* The document orb carries no mic/stop pair — it opens a file dialog in every
+     state, so its glyph shows whenever the button is visible. */
+  .pg-icon-doc { @apply block; }
   /* Recording shows the bars; hovering reveals the stop target instead. */
   .pg-orb-recording:hover .pg-icon-stop { @apply block; }
   .pg-orb-recording:hover .pg-bars { @apply hidden; }

--- a/app/controllers/api/v2/scribe_sessions_controller.rb
+++ b/app/controllers/api/v2/scribe_sessions_controller.rb
@@ -277,16 +277,6 @@ module Api
           render_error(code: "validation_error", message: "document too large", status: :unprocessable_entity)
           return
         end
-        existing_bytes = session.document_files.sum { |f| f.blob&.byte_size.to_i }
-        if existing_bytes + upload.size.to_i > ScribeSession::MAX_DOCUMENT_BYTES
-          render_error(
-            code: "document_upload_failed",
-            message: "total documents exceed #{ScribeSession::MAX_DOCUMENT_BYTES} bytes",
-            status: :unprocessable_entity
-          )
-          return
-        end
-
         pages = count_pages(upload, content_type)
         if pages.nil?
           render_error(
@@ -296,23 +286,56 @@ module Api
           )
           return
         end
-        if session.document_pages + pages > ScribeSession::MAX_DOCUMENT_PAGES
+
+        # Both cumulative ceilings are read-check-write against state this
+        # request is about to change, and a session token lets one client fire
+        # its uploads concurrently. Unlocked, two requests both read
+        # document_pages = 18, both see 18 + 2 <= 20, and the session lands at 22
+        # — over the cap that sizes the OCR request and the credit hold. Hold the
+        # session row for the whole check-attach-increment so the second request
+        # reads the first one's result. `with_lock` reloads inside the
+        # transaction, so the counts below are the locked row's, not the stale
+        # ones this action was dispatched with.
+        rejection = nil
+        too_late = false
+        session.with_lock do
+          # The status guard above is only a fast path: counting pages can take
+          # up to PDF_PARSE_TIMEOUT_SECONDS, and a commit racing that window
+          # moves the session to :processing and sizes its credit hold on the
+          # pages banked so far. Attaching after that point adds a page the hold
+          # never covered and the OCR call may never see. Re-assert under the
+          # lock, where the claim is serialized against commit's own UPDATE.
+          if !session.created? && !session.uploading?
+            too_late = true
+          elsif session.document_files.sum { |f| f.blob&.byte_size.to_i } + upload.size.to_i >
+                ScribeSession::MAX_DOCUMENT_BYTES
+            rejection = "total documents exceed #{ScribeSession::MAX_DOCUMENT_BYTES} bytes"
+          elsif session.document_pages + pages > ScribeSession::MAX_DOCUMENT_PAGES
+            rejection = "total pages exceed #{ScribeSession::MAX_DOCUMENT_PAGES}"
+          else
+            session.document_files.attach(
+              io: upload.tempfile.tap(&:rewind),
+              filename: upload.original_filename,
+              content_type: content_type
+            )
+            session.document_pages += pages
+            session.status = "uploading" if session.created?
+            session.save!
+          end
+        end
+
+        if too_late
           render_error(
-            code: "document_upload_failed",
-            message: "total pages exceed #{ScribeSession::MAX_DOCUMENT_PAGES}",
-            status: :unprocessable_entity
+            code: "validation_error",
+            message: "documents cannot be uploaded from status #{session.status}",
+            status: :conflict
           )
           return
         end
-
-        session.document_files.attach(
-          io: upload.tempfile.tap(&:rewind),
-          filename: upload.original_filename,
-          content_type: content_type
-        )
-        session.document_pages += pages
-        session.status = "uploading" if session.created?
-        session.save!
+        if rejection
+          render_error(code: "document_upload_failed", message: rejection, status: :unprocessable_entity)
+          return
+        end
 
         render json: { id: session.id, status: session.status, pages: session.document_pages }, status: :ok
       end
@@ -486,15 +509,51 @@ module Api
 
       # Page count for one uploaded document: pdf-reader for PDFs (nil when the
       # PDF is encrypted/unparseable — the caller 422s), 1 for images.
+      # Counts the pages of an UNTRUSTED PDF, on a Puma request thread. Two
+      # things make that dangerous, and both are handled here.
+      #
+      # 1. Unbounded work. pdf-reader builds the xref table by reading a subsection
+      #    header out of the file and looping that many times (xref.rb: `count =
+      #    params[1].to_i` then `count.times`). The integer is attacker-supplied
+      #    and Ruby's to_i is unbounded, so a 333-byte upload declaring
+      #    `0 4000000000` spins for hours. With RAILS_MAX_THREADS defaulting to 3,
+      #    three such uploads take down every endpoint for every account. The
+      #    wall-clock bound is the fix; Timeout::Error is a StandardError, so the
+      #    rescue below already turns an expiry into the same clean 422 a
+      #    malformed PDF gets.
+      #
+      # 2. A lying page count. #page_count returns the catalog's self-declared
+      #    /Count, which a hostile file sets to 1 while carrying 500 pages —
+      #    understating itself past MAX_DOCUMENT_PAGES and past the per-page
+      #    credit hold at commit, while still costing 500 pages of vision tokens.
+      #    #pages is no better: it is literally `(1..page_count).map`, so it
+      #    inherits the same lie. Only #page_references walks the real /Pages
+      #    tree, and its length is what the provider will actually process.
+      #    Walking is itself attacker-directed work, which is precisely why it
+      #    runs inside the timeout.
+      PDF_PARSE_TIMEOUT_SECONDS = 2
+
       def count_pages(upload, content_type)
         return 1 unless content_type == "application/pdf"
 
         upload.tempfile.rewind
-        count = PDF::Reader.new(upload.tempfile).page_count
-        upload.tempfile.rewind
+        count = Timeout.timeout(PDF_PARSE_TIMEOUT_SECONDS) do
+          reader = PDF::Reader.new(upload.tempfile)
+          # Cross-checked against the declared count and resolved in favour of
+          # whichever is larger, so neither an understated /Count nor a
+          # truncated tree walk can get a document billed for less than it is.
+          [ reader.objects.page_references.size, reader.page_count.to_i ].max
+        end
         count.positive? ? count : nil
-      rescue StandardError
+      # SystemStackError is caught explicitly because it is NOT a StandardError.
+      # #page_references walks /Kids with no cycle guard, so a 238-byte PDF whose
+      # /Pages node lists itself as its own kid recurses until the stack blows —
+      # in milliseconds, well inside the timeout. Without this the walk turns a
+      # file the old code accepted into a 500 on a public endpoint.
+      rescue SystemStackError, StandardError
         nil
+      ensure
+        upload.tempfile.rewind if upload.tempfile.respond_to?(:rewind)
       end
 
       # Undo a won commit claim (processing -> its prior committable status).

--- a/app/controllers/api/v2/scribe_sessions_controller.rb
+++ b/app/controllers/api/v2/scribe_sessions_controller.rb
@@ -262,11 +262,11 @@ module Api
           render_error(code: "validation_error", message: "document file is required", status: :unprocessable_entity)
           return
         end
-        content_type = base_audio_type(upload.content_type)
+        content_type = sniffed_document_type(upload)
         unless ScribeSession::ALLOWED_DOCUMENT_TYPES.include?(content_type)
           render_error(
             code: "validation_error",
-            message: "unsupported document content type: #{upload.content_type}",
+            message: "unsupported document content type: #{content_type}",
             status: :unprocessable_entity
           )
           return
@@ -305,7 +305,7 @@ module Api
           # lock, where the claim is serialized against commit's own UPDATE.
           if !session.created? && !session.uploading?
             too_late = true
-          elsif session.document_files.sum { |f| f.blob&.byte_size.to_i } + upload.size.to_i >
+          elsif attached_bytes_of(session, :document_files) + upload.size.to_i >
                 ScribeSession::MAX_DOCUMENT_BYTES
             rejection = "total documents exceed #{ScribeSession::MAX_DOCUMENT_BYTES} bytes"
           elsif session.document_pages + pages > ScribeSession::MAX_DOCUMENT_PAGES
@@ -511,6 +511,21 @@ module Api
           .sum(:byte_size)
       end
 
+      # The same sum for a has_many_attached on ONE record — the session's
+      # document_files. Bounded at 20 attachments (each is at least a page), so
+      # the Ruby-side version was only ever ~20 blob queries — but it ran under
+      # the session row lock, and one round trip there is better than twenty.
+      def attached_bytes_of(record, name)
+        ActiveStorage::Blob
+          .joins(:attachments)
+          .where(active_storage_attachments: {
+            record_type: record.class.polymorphic_name,
+            name: name.to_s,
+            record_id: record.id
+          })
+          .sum(:byte_size)
+      end
+
       # Renders a 409 and returns true when the session's modality does not
       # match the upload surface (audio uploads to a document session or vice
       # versa), so callers can guard with `return if reject_wrong_modality(...)`.
@@ -523,6 +538,31 @@ module Api
           status: :conflict
         )
         true
+      end
+
+      # What an uploaded document actually IS, decided from its bytes.
+      #
+      # The multipart Content-Type is a client claim, and everything downstream
+      # of this action disagrees with it: Active Storage re-identifies the blob
+      # from its magic bytes on attach (Blob#unfurl, identify: true) and the
+      # orchestrator hands the provider `blob.content_type`. So a multi-page PDF
+      # declared as image/jpeg would have been counted as ONE page here (images
+      # count as one), stored as application/pdf, and OCR'd as the whole PDF —
+      # under the 20-page cap, the per-page credit hold, per-page metering and
+      # the page-sized output budget, all of which this action exists to size.
+      # Sniffing with the same Marcel call Active Storage uses means the
+      # allowlist, the page count and the stored type all describe one file.
+      # It also turns "a GIF declared as image/jpeg" into a clean 422 here
+      # rather than a model validation failure (and 500) inside the lock below.
+      def sniffed_document_type(upload)
+        upload.tempfile.rewind
+        Marcel::MimeType.for(
+          upload.tempfile,
+          name: upload.original_filename.to_s,
+          declared_type: base_audio_type(upload.content_type)
+        ).to_s
+      ensure
+        upload.tempfile.rewind if upload.tempfile.respond_to?(:rewind)
       end
 
       # Page count for one uploaded document: pdf-reader for PDFs (nil when the

--- a/app/controllers/api/v2/scribe_sessions_controller.rb
+++ b/app/controllers/api/v2/scribe_sessions_controller.rb
@@ -589,6 +589,15 @@ module Api
       #    tree, and its length is what the provider will actually process.
       #    Walking is itself attacker-directed work, which is precisely why it
       #    runs inside the timeout.
+      #
+      # 3. Unbounded MEMORY, which the timeout does not touch. Every compressed
+      #    stream pdf-reader reads — the xref stream in PDF::Reader.new, the
+      #    object streams the tree walk visits — is inflated with no output cap,
+      #    and a few-hundred-byte nested FlateDecode stream decodes to
+      #    gigabytes in milliseconds: the process is OOM-killed long before the
+      #    2s timer fires, and no rescue catches a kernel kill. That bound lives
+      #    in config/initializers/pdf_reader_inflate_cap.rb, which caps each
+      #    inflate and raises MalformedPDFError (a StandardError) instead.
       PDF_PARSE_TIMEOUT_SECONDS = 2
 
       def count_pages(upload, content_type)

--- a/app/controllers/playground_controller.rb
+++ b/app/controllers/playground_controller.rb
@@ -14,6 +14,12 @@
 class PlaygroundController < ApplicationController
   before_action :set_template
 
+  # What the browser may ask for. A document run uploads a lab report to
+  # /documents and is extracted by vision OCR; an audio run records and uploads
+  # utterances to /audio/segments. Everything after the transcript exists is the
+  # same pipeline, which is exactly what makes running both from here worth it.
+  MODALITIES = %w[audio document].freeze
+
   # GET /templates/:template_id/playground
   def show
     # `set_template` already loaded the runnable pages, ordered and preloaded:
@@ -39,7 +45,7 @@ class PlaygroundController < ApplicationController
       user: current_user,
       outputs: @pages_with_fields.map { |page| { type: "form", page_id: page.id } },
       mode: "consultation",
-      modality: "audio",
+      modality: modality,
       language_hint: language_hint
     ).call
 
@@ -53,6 +59,7 @@ class PlaygroundController < ApplicationController
       session_id: result.session.id,
       token: token,
       expires_at: expires_at.iso8601,
+      modality: result.session.modality,
       pages: @pages_with_fields.map do |page|
         {
           id: page.id,
@@ -119,5 +126,12 @@ class PlaygroundController < ApplicationController
   # the stage special-cases it.
   def language_hint
     params[:language_hint].presence || "auto"
+  end
+
+  # Anything unrecognised runs as audio rather than 422-ing: the modality is a
+  # UI affordance here, not a contract, and SessionBuilder would reject a bad
+  # value with an error the playground has no useful way to explain.
+  def modality
+    MODALITIES.include?(params[:modality]) ? params[:modality] : "audio"
   end
 end

--- a/app/javascript/controllers/playground_controller.js
+++ b/app/javascript/controllers/playground_controller.js
@@ -68,7 +68,7 @@ export default class extends Controller {
     this.state = "idle"
     this.modality = "audio"
     this.files = []
-    this.committed = false
+    this.uploaded = false
     this.seq = 0
     this.inflight = 0
     this.session = null
@@ -138,8 +138,8 @@ export default class extends Controller {
     const doc = modality === "document"
     this.modeAudioTarget.className = `pg-mode${doc ? "" : " pg-mode-on"}`
     this.modeDocumentTarget.className = `pg-mode${doc ? " pg-mode-on" : ""}`
-    this.modeAudioTarget.setAttribute("aria-selected", String(!doc))
-    this.modeDocumentTarget.setAttribute("aria-selected", String(doc))
+    this.modeAudioTarget.setAttribute("aria-pressed", String(!doc))
+    this.modeDocumentTarget.setAttribute("aria-pressed", String(doc))
 
     this.recordTarget.classList.toggle("hidden", doc)
     this.pickTarget.classList.toggle("hidden", !doc)
@@ -163,7 +163,12 @@ export default class extends Controller {
     this.fileInputTarget.click()
   }
 
+  // The sr-only input is still keyboard-reachable, so this can fire mid-run
+  // even though the orb refuses to open the dialog then. Swapping the file list
+  // under a running upload loop would arm Extract for a second, concurrent
+  // session — ignore it, the way every other control is inert while busy.
   filesChosen() {
+    if (this.state === "processing") return
     this.hideError()
     this.files = Array.from(this.fileInputTarget.files || [])
     this.renderFileList()
@@ -206,7 +211,7 @@ export default class extends Controller {
     }
 
     list.classList.toggle("hidden", this.files.length === 0)
-    this.extractTarget.disabled = this.files.length === 0 || Boolean(rejection)
+    this.extractTarget.disabled = this.state === "processing" || this.files.length === 0 || Boolean(rejection)
     if (rejection) this.showError(rejection)
 
     if (this.files.length && !rejection && this.state === "idle") {
@@ -216,14 +221,18 @@ export default class extends Controller {
   }
 
   async extract() {
+    // A second Extract while the first is uploading would open a second
+    // session against the same files; the button is disabled while busy, but
+    // the guard belongs here too, where the session is actually created.
+    if (this.state === "processing") return
     if (!this.files.length || this.rejectionFor(this.files)) return
 
     this.hideError()
     this.resetFields()
     this.setState("processing")
-    // Cleared until the commit lands, so retry() knows whether the session on
-    // the server is a complete document or a half-uploaded one.
-    this.committed = false
+    // Cleared until every file has landed, so retry() knows whether the session
+    // on the server holds the complete document or a half-uploaded one.
+    this.uploaded = false
 
     try {
       const session = await this.createSession()
@@ -239,9 +248,14 @@ export default class extends Controller {
         body.append("document", file, file.name)
         await this.apiFetch(`/scribe_sessions/${this.session}/documents`, { method: "POST", body })
       }
+      // Set BEFORE the commit, not after it: once every page is stored the
+      // session is complete, and if the commit call itself fails — or the
+      // server accepts it and the response is lost — the honest retry is to
+      // commit THAT session again, not to upload the whole report to a new one
+      // (which, when the first commit had in fact landed, bills two OCR runs).
+      this.uploaded = true
 
       await this.apiFetch(`/scribe_sessions/${this.session}/commit`, { method: "POST" })
-      this.committed = true
       this.startPolling(POLL_MS_PROCESSING)
     } catch (err) {
       this.fail(err.message, { retryable: true })
@@ -267,7 +281,7 @@ export default class extends Controller {
   // the server-side truncation guard exists to prevent. Start over instead, on
   // a fresh session, so every page is uploaded again.
   async retry() {
-    if (this.modality === "document" && !this.committed) {
+    if (this.modality === "document" && !this.uploaded) {
       this.session = null
       this.token = null
       return this.extract()
@@ -710,6 +724,9 @@ export default class extends Controller {
     this.recordTarget.setAttribute("aria-label", recording ? "Stop recording" : "Start recording")
     this.pickTarget.className = `pg-orb pg-orb-${busy ? "busy" : "idle"}${document_ ? "" : " hidden"}`
     this.pickTarget.disabled = busy
+    // The input itself too: it is sr-only, not display:none, so it is still in
+    // the tab order when the orb that fronts it is disabled.
+    this.fileInputTarget.disabled = busy
     this.extractTarget.disabled = busy || this.files.length === 0 || Boolean(this.rejectionFor(this.files))
 
     // A mid-run switch would orphan a session that is already being billed.

--- a/app/javascript/controllers/playground_controller.js
+++ b/app/javascript/controllers/playground_controller.js
@@ -293,6 +293,13 @@ export default class extends Controller {
       await this.apiFetch(`/scribe_sessions/${this.session}/commit`, { method: "POST" })
       this.startPolling(POLL_MS_PROCESSING)
     } catch (err) {
+      // A commit refused because the session is ALREADY processing (or done)
+      // means an earlier commit landed and only its response was lost — the
+      // run is under way. Poll it rather than dead-end on a 409 whose text
+      // says, in effect, "it's working".
+      if (err.status === 409 && /from status (processing|completed)/.test(err.message)) {
+        return this.startPolling(POLL_MS_PROCESSING)
+      }
       this.fail(err.message, { retryable: true })
     }
   }
@@ -644,7 +651,12 @@ export default class extends Controller {
     if (!response.ok) {
       // 401 carries no body at all, so this must not assume JSON.
       const payload = await response.json().catch(() => ({}))
-      throw new Error(payload.error?.message || `Request failed (${response.status})`)
+      const error = new Error(payload.error?.message || `Request failed (${response.status})`)
+      // Callers that need to tell one failure from another (retry() reading a
+      // 409 as "already running") get the status and API code, not just prose.
+      error.status = response.status
+      error.code = payload.error?.code
+      throw error
     }
 
     return response.status === 204 ? {} : response.json()

--- a/app/javascript/controllers/playground_controller.js
+++ b/app/javascript/controllers/playground_controller.js
@@ -1,13 +1,22 @@
 import { Controller } from "@hotwired/stimulus"
 
-// The template playground recorder.
+// The template playground: run this template against real input, two ways.
 //
-// Voice-activity detection (Silero, via the vendored @ricky0123/vad-web) cuts
-// the mic stream into whole utterances. Each utterance is POSTed to
+// AUDIO. Voice-activity detection (Silero, via the vendored @ricky0123/vad-web)
+// cuts the mic stream into whole utterances. Each utterance is POSTed to
 // /audio/segments as its own WAV, which is what that endpoint wants — an
 // independently decodable part it can transcribe on arrival. That is what buys
 // the transcript that grows while the user is still talking; the sibling
 // /audio/chunks endpoint byte-concatenates its parts and could not decode them.
+//
+// DOCUMENT. A lab report (PDF, or a photo per page) is POSTed to /documents,
+// one file per request and strictly in order — attachment id is upload order is
+// reading order, and the server OCRs them as one document in that order. The
+// server counts pages, which the browser cannot, so it owns the real ceilings.
+//
+// The two differ only in how the transcript comes to exist. Commit, polling,
+// structuring, metering and the rendered result are one shared path from there,
+// which is the point of running both from this page.
 //
 // Everything after session creation talks to the public /api/v2 with a
 // short-lived `mss_` token, so this page exercises the same API a customer
@@ -38,7 +47,9 @@ export default class extends Controller {
   static targets = [
     "record", "orbIcon", "bars", "statusLabel", "statusHint", "steps", "timer",
     "pause", "error", "errorMessage", "retry", "transcriptCard",
-    "transcriptBadge", "transcript", "fields", "result"
+    "transcriptBadge", "transcript", "fields", "result",
+    "modeAudio", "modeDocument", "audioControls", "documentControls",
+    "pick", "fileInput", "extract", "fileList", "stepZero", "transcriptTitle"
   ]
 
   static values = {
@@ -47,11 +58,17 @@ export default class extends Controller {
     resultUrl: String,
     apiBase: String,
     vadBase: String,
-    ortBase: String
+    ortBase: String,
+    maxFileBytes: Number,
+    maxTotalBytes: Number,
+    documentTypes: Array
   }
 
   connect() {
     this.state = "idle"
+    this.modality = "audio"
+    this.files = []
+    this.committed = false
     this.seq = 0
     this.inflight = 0
     this.session = null
@@ -100,10 +117,162 @@ export default class extends Controller {
     }
   }
 
-  // Re-commit. A commit fails as a unit when any segment has not settled, and
-  // re-committing retries exactly those — so the honest retry is the same call,
-  // not a fresh recording.
+  // ── source mode ──────────────────────────────────────────────────────────
+
+  useAudio() { this.setModality("audio") }
+  useDocument() { this.setModality("document") }
+
+  // Switching mid-run would orphan a session that is already being billed, so
+  // the switch is inert once something is under way; setState re-disables the
+  // buttons for the same reason.
+  setModality(modality) {
+    if (this.modality === modality) return
+    if (["preparing", "recording", "paused", "processing"].includes(this.state)) return
+
+    this.modality = modality
+    this.session = null
+    this.token = null
+    this.files = []
+    this.fileInputTarget.value = ""
+
+    const doc = modality === "document"
+    this.modeAudioTarget.className = `pg-mode${doc ? "" : " pg-mode-on"}`
+    this.modeDocumentTarget.className = `pg-mode${doc ? " pg-mode-on" : ""}`
+    this.modeAudioTarget.setAttribute("aria-selected", String(!doc))
+    this.modeDocumentTarget.setAttribute("aria-selected", String(doc))
+
+    this.recordTarget.classList.toggle("hidden", doc)
+    this.pickTarget.classList.toggle("hidden", !doc)
+    this.audioControlsTarget.classList.toggle("hidden", doc)
+    this.documentControlsTarget.classList.toggle("flex", doc)
+    this.documentControlsTarget.classList.toggle("hidden", !doc)
+
+    this.transcriptTitleTarget.textContent = doc ? "Extracted text" : "Transcript"
+    this.stepZeroTarget.textContent = doc ? "Reading document" : "Transcribing"
+
+    this.hideError()
+    this.resetFields()
+    this.renderFileList()
+    this.setState("idle")
+  }
+
+  // ── documents ────────────────────────────────────────────────────────────
+
+  chooseFiles() {
+    if (this.state === "processing") return
+    this.fileInputTarget.click()
+  }
+
+  filesChosen() {
+    this.hideError()
+    this.files = Array.from(this.fileInputTarget.files || [])
+    this.renderFileList()
+  }
+
+  // Local pre-flight only. The server re-checks every one of these on arrival
+  // and additionally counts pages, so this exists to spend a message instead of
+  // an upload — never to decide what is allowed.
+  rejectionFor(files) {
+    const types = this.documentTypesValue || []
+    const bad = files.find((file) => file.type && types.length && !types.includes(file.type))
+    if (bad) return `${bad.name} is not a PDF or an image.`
+
+    const tooBig = files.find((file) => file.size > this.maxFileBytesValue)
+    if (tooBig) return `${tooBig.name} is larger than ${this.formatBytes(this.maxFileBytesValue)}.`
+
+    const total = files.reduce((sum, file) => sum + file.size, 0)
+    if (total > this.maxTotalBytesValue) {
+      return `Those files total ${this.formatBytes(total)}, over the ${this.formatBytes(this.maxTotalBytesValue)} limit.`
+    }
+    return null
+  }
+
+  renderFileList() {
+    const list = this.fileListTarget
+    list.innerHTML = ""
+    const rejection = this.files.length ? this.rejectionFor(this.files) : null
+
+    for (const file of this.files) {
+      const row = document.createElement("li")
+      row.className = "flex items-center justify-between gap-3 rounded-lg border border-gray-200 px-3 py-2"
+      const name = document.createElement("span")
+      name.className = "min-w-0 flex-1 truncate text-sm text-gray-700"
+      name.textContent = file.name
+      const size = document.createElement("span")
+      size.className = "num shrink-0 text-xs tabular-nums text-gray-400"
+      size.textContent = this.formatBytes(file.size)
+      row.append(name, size)
+      list.append(row)
+    }
+
+    list.classList.toggle("hidden", this.files.length === 0)
+    this.extractTarget.disabled = this.files.length === 0 || Boolean(rejection)
+    if (rejection) this.showError(rejection)
+
+    if (this.files.length && !rejection && this.state === "idle") {
+      this.statusHintTarget.textContent =
+        `${this.files.length} ${this.files.length === 1 ? "file" : "files"} ready. Press Extract.`
+    }
+  }
+
+  async extract() {
+    if (!this.files.length || this.rejectionFor(this.files)) return
+
+    this.hideError()
+    this.resetFields()
+    this.setState("processing")
+    // Cleared until the commit lands, so retry() knows whether the session on
+    // the server is a complete document or a half-uploaded one.
+    this.committed = false
+
+    try {
+      const session = await this.createSession()
+      this.session = session.session_id
+      this.token = session.token
+
+      // Strictly sequential: attachment id is upload order is the order the
+      // report is transcribed in, so racing these would shuffle the pages of a
+      // photographed report. The per-request row lock makes concurrency safe,
+      // not correct.
+      for (const file of this.files) {
+        const body = new FormData()
+        body.append("document", file, file.name)
+        await this.apiFetch(`/scribe_sessions/${this.session}/documents`, { method: "POST", body })
+      }
+
+      await this.apiFetch(`/scribe_sessions/${this.session}/commit`, { method: "POST" })
+      this.committed = true
+      this.startPolling(POLL_MS_PROCESSING)
+    } catch (err) {
+      this.fail(err.message, { retryable: true })
+    }
+  }
+
+  formatBytes(bytes) {
+    if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+    if (bytes >= 1024) return `${Math.round(bytes / 1024)} KB`
+    return `${bytes} B`
+  }
+
+  // Re-commit. For audio, a commit fails as a unit when any segment has not
+  // settled and re-committing retries exactly those. For a document session the
+  // uploads are already stored, so this re-runs OCR against them — which is a
+  // fresh provider call and is billed as one.
+  //
+  // EXCEPT when the upload loop itself broke. The loop aborts on the first
+  // failure, so page 2 of 3 dropping leaves ONE page on the server — and
+  // commit's gate only requires that some document is attached. Re-committing
+  // there would OCR a third of a lab report, structure it, and finish green: a
+  // partial clinical document presented as complete, which is precisely what
+  // the server-side truncation guard exists to prevent. Start over instead, on
+  // a fresh session, so every page is uploaded again.
   async retry() {
+    if (this.modality === "document" && !this.committed) {
+      this.session = null
+      this.token = null
+      return this.extract()
+    }
+
     this.hideError()
     this.setState("processing")
     try {
@@ -329,7 +498,11 @@ export default class extends Controller {
   }
 
   async complete(payload) {
-    this.transcriptBadgeTarget.textContent = payload.transcript?.language || "Done"
+    // "auto" is the no-hint sentinel, not a detected language — a document
+    // transcript carries the session's hint verbatim because OCR detects
+    // nothing, so it would otherwise surface as a badge reading "auto".
+    const language = payload.transcript?.language
+    this.transcriptBadgeTarget.textContent = language && language !== "auto" ? language : "Done"
     this.transcriptBadgeTarget.className = "badge badge-neutral"
 
     await this.fillFields(payload)
@@ -394,7 +567,7 @@ export default class extends Controller {
     })
     this.transcriptTarget.textContent = ""
     this.transcriptCardTarget.classList.add("hidden")
-    this.transcriptBadgeTarget.textContent = "Listening"
+    this.transcriptBadgeTarget.textContent = this.modality === "document" ? "Reading" : "Listening"
     this.transcriptBadgeTarget.className = "badge badge-progress"
   }
 
@@ -417,7 +590,10 @@ export default class extends Controller {
       .flatMap((output) => output.errors || [])
       .map((error) => (typeof error === "string" ? error : error.message))
       .filter(Boolean)
-    return fromOutputs[0] || "This run failed. Retry to try the same audio again."
+    if (fromOutputs[0]) return fromOutputs[0]
+    return this.modality === "document"
+      ? "This run failed. Retry to read the same document again."
+      : "This run failed. Retry to try the same audio again."
   }
 
   // ── transport ────────────────────────────────────────────────────────────
@@ -430,7 +606,7 @@ export default class extends Controller {
         Accept: "application/json",
         "X-CSRF-Token": document.querySelector('meta[name="csrf-token"]')?.content || ""
       },
-      body: JSON.stringify({})
+      body: JSON.stringify({ modality: this.modality })
     })
     const payload = await response.json().catch(() => ({}))
     if (!response.ok) throw new Error(payload.error?.message || "Could not start a session.")
@@ -501,16 +677,24 @@ export default class extends Controller {
 
   setState(state) {
     this.state = state
+    const document_ = this.modality === "document"
 
-    const copy = {
+    const shared = {
+      done: ["Done", "This ran through the same pipeline your integration will."],
+      failed: ["Something went wrong", "Nothing was charged for a run that failed to transcribe."]
+    }
+    const copy = (document_ ? {
+      ...shared,
+      processing: ["Working on it", "Reading the document, then filling the form."],
+      idle: ["Ready when you are", "Choose a lab report — a PDF, or a photo per page."]
+    } : {
+      ...shared,
       preparing: ["Getting ready", "Loading the recogniser and asking for your microphone."],
       recording: ["Listening", "Speak naturally. Pauses are fine — it splits on them."],
       paused: ["Paused", "Resume when you are ready."],
       processing: ["Working on it", "Transcribing what you said, then filling the form."],
-      done: ["Done", "This ran through the same pipeline your integration will."],
-      failed: ["Something went wrong", "Nothing was charged for a run that failed to transcribe."],
       idle: ["Ready when you are", "Press record and describe a consultation out loud."]
-    }[state] || ["", ""]
+    })[state] || ["", ""]
 
     this.statusLabelTarget.textContent = copy[0]
     this.statusHintTarget.textContent = copy[1]
@@ -519,15 +703,25 @@ export default class extends Controller {
     this.statusHintTarget.className = "mt-0.5 text-sm text-gray-500"
 
     const recording = state === "recording" || state === "paused"
-    this.recordTarget.className = `pg-orb pg-orb-${state === "processing" ? "busy" : recording ? "recording" : "idle"}`
-    this.recordTarget.disabled = state === "preparing" || state === "processing"
+    const busy = state === "processing"
+    this.recordTarget.className =
+      `pg-orb pg-orb-${busy ? "busy" : recording ? "recording" : "idle"}${document_ ? " hidden" : ""}`
+    this.recordTarget.disabled = state === "preparing" || busy
     this.recordTarget.setAttribute("aria-label", recording ? "Stop recording" : "Start recording")
+    this.pickTarget.className = `pg-orb pg-orb-${busy ? "busy" : "idle"}${document_ ? "" : " hidden"}`
+    this.pickTarget.disabled = busy
+    this.extractTarget.disabled = busy || this.files.length === 0 || Boolean(this.rejectionFor(this.files))
+
+    // A mid-run switch would orphan a session that is already being billed.
+    this.modeAudioTarget.disabled = busy || state === "preparing" || recording
+    this.modeDocumentTarget.disabled = this.modeAudioTarget.disabled
+
     this.barsTarget.classList.toggle("hidden", !recording)
     this.timerTarget.classList.toggle("hidden", !recording)
     this.pauseTarget.classList.toggle("hidden", !recording)
     this.pauseTarget.textContent = state === "paused" ? "Resume" : "Pause"
-    this.stepsTarget.classList.toggle("hidden", state !== "processing")
-    if (state === "processing") {
+    this.stepsTarget.classList.toggle("hidden", !busy)
+    if (busy) {
       this.setStep(0)
       // The mic is closed by now, so "Listening" would be a lie.
       this.transcriptBadgeTarget.textContent = "In progress"

--- a/app/serializers/scribe_session_serializer.rb
+++ b/app/serializers/scribe_session_serializer.rb
@@ -27,8 +27,16 @@ class ScribeSessionSerializer
   # token) can see what this session cost — not just the internal admin. Summed
   # in Ruby from the loaded usage_events association (preloaded on the index) so
   # a session list stays free of an N+1.
+  #
+  # Finalized events only. A billed-but-unusable attempt (a truncated OCR
+  # response the provider still charged us for) is written as a :failed event so
+  # the ledger shows our cost, but it is deliberately not deducted from the
+  # customer's credits — the API promises a run that produced nothing costs
+  # nothing. This object is what the customer reads as "what I was charged", so
+  # it must add up the same way the credit ledger does; the admin usage page
+  # already filters to finalized for the same reason.
   def serialize_usage
-    events = @session.usage_events.to_a
+    events = @session.usage_events.select(&:finalized?)
     {
       cost: events.sum { |e| e.cost.to_f },
       total_tokens: events.sum { |e| e.total_tokens.to_i },

--- a/app/services/llm/adapter.rb
+++ b/app/services/llm/adapter.rb
@@ -25,7 +25,38 @@ module Llm
       raise Llm::BadResponse, "#{self.class.name.demodulize} does not support document OCR"
     end
 
+    # finish_reasons meaning the model stopped because it was DONE. Anthropic
+    # says "end_turn", OpenAI says "stop"; anything else ("max_tokens",
+    # "length", a refusal) means the output is partial.
+    OCR_COMPLETE = %w[stop end_turn].freeze
+
     private
+
+    # A truncated extraction arrives as a 200 carrying half a lab report, and
+    # nothing downstream can tell the difference — structuring reads it, the
+    # session goes :completed, and a clinician sees a green result over a
+    # partial document.
+    #
+    # This lives in the base class so both vision adapters enforce one rule, and
+    # is called from inside the adapter (not from OcrStage) deliberately: only a
+    # raise that happens DURING the attempt is visible to Llm::Caller, which is
+    # what turns a truncation into a fallback attempt on the secondary provider
+    # rather than an immediate session failure. BadResponse is one of
+    # Caller::TRANSIENT for exactly that reason.
+    # `usage` is passed through onto the error because a truncated response is a
+    # response: the provider counted those tokens and will bill them. Carrying
+    # it lets the orchestrator record the attempt rather than absorb the cost.
+    def guard_ocr_completion!(finish_reason, usage: nil, latency_ms: nil)
+      return if finish_reason.nil? || OCR_COMPLETE.include?(finish_reason.to_s)
+
+      raise Llm::BadResponse.new(
+        "OCR did not complete (finish_reason=#{finish_reason}); " \
+        "the document was too long for the model's output budget",
+        usage: usage, latency_ms: latency_ms,
+        provider: config.provider_name || config.provider_kind.to_s,
+        model: config.api_model_id
+      )
+    end
 
     # Maps a Faraday error (raised via `f.response :raise_error`) to an Llm error.
     # Mapped by HTTP status where available, falling back to exception class.

--- a/app/services/llm/adapter.rb
+++ b/app/services/llm/adapter.rb
@@ -29,8 +29,43 @@ module Llm
     # says "end_turn", OpenAI says "stop"; anything else ("max_tokens",
     # "length", a refusal) means the output is partial.
     OCR_COMPLETE = %w[stop end_turn].freeze
+    # finish_reasons meaning the model DECLINED: Anthropic's "refusal", the
+    # OpenAI family's "content_filter". Distinct from truncation — a bigger
+    # budget will not help, and Llm::Caller does not fall back on a refusal.
+    OCR_REFUSED = %w[refusal content_filter].freeze
+
+    # The largest completion an adapter's models are assumed to accept when the
+    # model itself does not say. Providers reject — with a 400, before doing any
+    # work — a request whose output budget exceeds the model's ceiling, so a
+    # budget sized only from the page count would fail every long document
+    # outright rather than attempt it. Concrete adapters override this with the
+    # floor of their current model line; a model that allows more declares it in
+    # capabilities.max_output_tokens (see #ocr_output_ceiling).
+    DEFAULT_OUTPUT_CEILING = 4096
 
     private
+
+    # Caps an OCR output budget at what THIS model will accept. Applied per
+    # adapter (rather than once in OcrStage) because a primary and its fallback
+    # can be different models with different ceilings while receiving the same
+    # requested budget: gpt-4o-mini takes 16k, an older Claude 8k, and the
+    # fallback attempt must not 400 on a number that suited the primary.
+    #
+    # The ceiling comes from the model's capabilities.max_output_tokens when an
+    # admin has recorded it, else the assignment's options.max_output_tokens,
+    # else the adapter's conservative default. A too-low ceiling degrades to an
+    # honest truncation failure (guard_ocr_completion!, then fallback); a
+    # too-high one is a hard 400 — which is why the defaults are conservative.
+    def clamp_ocr_budget(max_tokens)
+      return nil if max_tokens.nil?
+
+      [ max_tokens.to_i, ocr_output_ceiling ].min
+    end
+
+    def ocr_output_ceiling
+      declared = config.capabilities[:max_output_tokens] || config.options[:max_output_tokens]
+      declared.to_i.positive? ? declared.to_i : self.class::DEFAULT_OUTPUT_CEILING
+    end
 
     # A truncated extraction arrives as a 200 carrying half a lab report, and
     # nothing downstream can tell the difference — structuring reads it, the
@@ -49,10 +84,32 @@ module Llm
     def guard_ocr_completion!(finish_reason, usage: nil, latency_ms: nil)
       return if finish_reason.nil? || OCR_COMPLETE.include?(finish_reason.to_s)
 
-      raise Llm::BadResponse.new(
+      # A refusal is not a truncation: telling the client "the document was too
+      # long" would send them looking at the wrong thing, and Llm::Refused is
+      # outside Caller::TRANSIENT, so it is not retried on the fallback — a
+      # refusal is a decision, not a fault. Still billed, so it carries usage.
+      if OCR_REFUSED.include?(finish_reason.to_s)
+        raise Llm::Refused.new(
+          "OCR was refused by the provider (finish_reason=#{finish_reason})",
+          usage: usage, latency_ms: latency_ms,
+          provider: config.provider_name || config.provider_kind.to_s,
+          model: config.api_model_id
+        )
+      end
+
+      raise billed_ocr_error(
         "OCR did not complete (finish_reason=#{finish_reason}); " \
         "the document was too long for the model's output budget",
-        usage: usage, latency_ms: latency_ms,
+        usage: usage, latency_ms: latency_ms
+      )
+    end
+
+    # A BadResponse for a 200 the provider will bill us for but that we cannot
+    # use (truncated, empty, malformed). One constructor so every vision adapter
+    # tags the error with the same provider/model the ledger expects.
+    def billed_ocr_error(message, usage: nil, latency_ms: nil)
+      Llm::BadResponse.new(
+        message, usage: usage, latency_ms: latency_ms,
         provider: config.provider_name || config.provider_kind.to_s,
         model: config.api_model_id
       )

--- a/app/services/llm/adapter.rb
+++ b/app/services/llm/adapter.rb
@@ -52,9 +52,13 @@ module Llm
     # fallback attempt must not 400 on a number that suited the primary.
     #
     # The ceiling comes from the model's capabilities.max_output_tokens when an
-    # admin has recorded it, else the assignment's options.max_output_tokens,
-    # else the adapter's conservative default. A too-low ceiling degrades to an
-    # honest truncation failure (guard_ocr_completion!, then fallback); a
+    # admin has recorded it, else the adapter's conservative default. It is a
+    # MODEL property and is read only from the model row, never from the
+    # assignment's options: ConfigResolver hands the primary assignment's
+    # options to the fallback Config as well, so an options-declared ceiling
+    # would be applied to a different model on the fallback path — exactly the
+    # over-ceiling 400 this clamp exists to prevent. A too-low ceiling degrades
+    # to an honest truncation failure (guard_ocr_completion!, then fallback); a
     # too-high one is a hard 400 — which is why the defaults are conservative.
     def clamp_ocr_budget(max_tokens)
       return nil if max_tokens.nil?
@@ -63,8 +67,8 @@ module Llm
     end
 
     def ocr_output_ceiling
-      declared = config.capabilities[:max_output_tokens] || config.options[:max_output_tokens]
-      declared.to_i.positive? ? declared.to_i : self.class::DEFAULT_OUTPUT_CEILING
+      declared = config.capabilities[:max_output_tokens].to_i
+      declared.positive? ? declared : self.class::DEFAULT_OUTPUT_CEILING
     end
 
     # A truncated extraction arrives as a 200 carrying half a lab report, and

--- a/app/services/llm/adapters/anthropic.rb
+++ b/app/services/llm/adapters/anthropic.rb
@@ -16,6 +16,10 @@ module Llm
       ANTHROPIC_VERSION = "2023-06-01".freeze
       DEFAULT_MAX_TOKENS = 4096
       TOOL_NAME = "extraction".freeze
+      # Every Claude 3.5+ model accepts at least 8k output tokens; the API 400s a
+      # max_tokens above the model's ceiling. Newer lines allow far more (64k)
+      # and should say so in capabilities.max_output_tokens.
+      DEFAULT_OUTPUT_CEILING = 8_192
 
       # Anthropic exposes no audio transcription endpoint. The capability flag
       # can_transcribe is false for these providers; this guard makes a
@@ -49,9 +53,11 @@ module Llm
       #
       # max_tokens is supplied by OcrStage, sized from the page count: the
       # DEFAULT_MAX_TOKENS below is a structuring budget and truncates a
-      # multi-page report. Whether the response actually completed is checked by
-      # OcrStage#guard_completion! against the finish_reason returned here, so
-      # the guard is applied identically to every provider.
+      # multi-page report. Whether the response actually completed is checked
+      # HERE, by the shared Llm::Adapter#guard_ocr_completion!, so the rule is
+      # identical for every provider AND the raise happens inside the attempt,
+      # where Llm::Caller can see it and spend the fallback.
+      # OcrStage#guard_completion! is only the backstop.
       def ocr(documents:, prompt: nil, max_tokens: nil, **_opts)
         started = monotonic
 
@@ -60,15 +66,18 @@ module Llm
 
         response = client.post("/v1/messages", {
           model: config.api_model_id,
-          max_tokens: max_tokens || config.options[:max_tokens] || DEFAULT_MAX_TOKENS,
+          max_tokens: clamp_ocr_budget(max_tokens) || config.options[:max_tokens] || DEFAULT_MAX_TOKENS,
           messages: [ { role: "user", content: blocks } ]
         })
         resp = response.body
         usage = usage_from(resp["usage"])
+        # Measured once so the error metadata and the Result agree on what this
+        # attempt cost in time.
+        elapsed = elapsed_ms(started)
         # Ordered before #extract_text: a max_tokens stop still carries real
         # text, so the blank check below would wave it through.
-        guard_ocr_completion!(resp["stop_reason"], usage: usage, latency_ms: elapsed_ms(started))
-        text = extract_text(resp, usage: usage, latency_ms: elapsed_ms(started))
+        guard_ocr_completion!(resp["stop_reason"], usage: usage, latency_ms: elapsed)
+        text = extract_text(resp, usage: usage, latency_ms: elapsed)
 
         Llm::Result.new(
           text: text,
@@ -76,7 +85,7 @@ module Llm
           provider: config.provider_name || config.provider_kind.to_s,
           usage: usage,
           finish_reason: resp["stop_reason"],
-          latency_ms: elapsed_ms(started),
+          latency_ms: elapsed,
           raw: resp
         )
       rescue Faraday::Error => e
@@ -101,22 +110,16 @@ module Llm
       def extract_text(resp, usage: nil, latency_ms: nil)
         blocks = resp["content"]
         unless blocks.is_a?(Array)
-          raise bad_ocr_response("Anthropic response missing content blocks", usage, latency_ms)
+          raise billed_ocr_error("Anthropic response missing content blocks", usage: usage, latency_ms: latency_ms)
         end
 
         text = blocks.select { |b| b.is_a?(Hash) && b["type"] == "text" }
                      .map { |b| b["text"] }.join("\n")
-        raise bad_ocr_response("Anthropic response contained no OCR text", usage, latency_ms) if text.blank?
+        if text.blank?
+          raise billed_ocr_error("Anthropic response contained no OCR text", usage: usage, latency_ms: latency_ms)
+        end
 
         text
-      end
-
-      def bad_ocr_response(message, usage, latency_ms)
-        Llm::BadResponse.new(
-          message, usage: usage, latency_ms: latency_ms,
-          provider: config.provider_name || config.provider_kind.to_s,
-          model: config.api_model_id
-        )
       end
 
       def request_body(messages, schema)

--- a/app/services/llm/adapters/anthropic.rb
+++ b/app/services/llm/adapters/anthropic.rb
@@ -46,7 +46,13 @@ module Llm
 
       # Document OCR via the Messages API with native image / document (PDF)
       # content blocks. Returns the full extracted text as Result#text.
-      def ocr(documents:, prompt: nil, **_opts)
+      #
+      # max_tokens is supplied by OcrStage, sized from the page count: the
+      # DEFAULT_MAX_TOKENS below is a structuring budget and truncates a
+      # multi-page report. Whether the response actually completed is checked by
+      # OcrStage#guard_completion! against the finish_reason returned here, so
+      # the guard is applied identically to every provider.
+      def ocr(documents:, prompt: nil, max_tokens: nil, **_opts)
         started = monotonic
 
         blocks = documents.map { |doc| document_block(doc) }
@@ -54,17 +60,21 @@ module Llm
 
         response = client.post("/v1/messages", {
           model: config.api_model_id,
-          max_tokens: config.options[:max_tokens] || DEFAULT_MAX_TOKENS,
+          max_tokens: max_tokens || config.options[:max_tokens] || DEFAULT_MAX_TOKENS,
           messages: [ { role: "user", content: blocks } ]
         })
         resp = response.body
-        text = extract_text(resp)
+        usage = usage_from(resp["usage"])
+        # Ordered before #extract_text: a max_tokens stop still carries real
+        # text, so the blank check below would wave it through.
+        guard_ocr_completion!(resp["stop_reason"], usage: usage, latency_ms: elapsed_ms(started))
+        text = extract_text(resp, usage: usage, latency_ms: elapsed_ms(started))
 
         Llm::Result.new(
           text: text,
           model: config.api_model_id,
           provider: config.provider_name || config.provider_kind.to_s,
-          usage: usage_from(resp["usage"]),
+          usage: usage,
           finish_reason: resp["stop_reason"],
           latency_ms: elapsed_ms(started),
           raw: resp
@@ -84,17 +94,29 @@ module Llm
         { type: doc[:content_type] == "application/pdf" ? "document" : "image", source: source }
       end
 
-      # Joined text blocks. A 2xx with no text is a bad response (refusal or
-      # truncation) and triggers fallback upstream.
-      def extract_text(resp)
+      # Joined text blocks. A 2xx with no text is a bad response (a refusal, or
+      # a completion that spent its budget on nothing) and triggers fallback
+      # upstream. It is still a billed round-trip, so the usage rides along on
+      # the error for the ledger.
+      def extract_text(resp, usage: nil, latency_ms: nil)
         blocks = resp["content"]
-        raise Llm::BadResponse, "Anthropic response missing content blocks" unless blocks.is_a?(Array)
+        unless blocks.is_a?(Array)
+          raise bad_ocr_response("Anthropic response missing content blocks", usage, latency_ms)
+        end
 
         text = blocks.select { |b| b.is_a?(Hash) && b["type"] == "text" }
                      .map { |b| b["text"] }.join("\n")
-        raise Llm::BadResponse, "Anthropic response contained no OCR text" if text.blank?
+        raise bad_ocr_response("Anthropic response contained no OCR text", usage, latency_ms) if text.blank?
 
         text
+      end
+
+      def bad_ocr_response(message, usage, latency_ms)
+        Llm::BadResponse.new(
+          message, usage: usage, latency_ms: latency_ms,
+          provider: config.provider_name || config.provider_kind.to_s,
+          model: config.api_model_id
+        )
       end
 
       def request_body(messages, schema)

--- a/app/services/llm/adapters/openai_compatible.rb
+++ b/app/services/llm/adapters/openai_compatible.rb
@@ -70,8 +70,8 @@ module Llm
       # max_tokens is supplied by OcrStage, sized from the page count. Sending
       # none left the extraction capped at whatever the endpoint's default
       # happened to be, which for a multi-page report is a truncation waiting to
-      # happen. `max_tokens` (rather than `max_completion_tokens`) is what every
-      # OpenAI-compatible endpoint this adapter targets understands.
+      # happen. The parameter NAME depends on the endpoint — see
+      # #output_budget_param.
       def ocr(documents:, prompt: nil, max_tokens: nil, **_opts)
         started = monotonic
         parts = [ { type: "text", text: prompt.to_s } ]
@@ -81,7 +81,7 @@ module Llm
           model: config.api_model_id,
           messages: [ { role: "user", content: parts } ]
         }
-        params[:max_tokens] = max_tokens if max_tokens
+        params[output_budget_param] = clamp_ocr_budget(max_tokens) if max_tokens
         response = client.chat(parameters: params)
         choice = response.dig("choices", 0) || {}
         finish_reason = choice["finish_reason"]
@@ -93,13 +93,7 @@ module Llm
         # so one rule decides what "complete" means for every vision provider.
         # Both raises carry the usage: an unusable 200 is still a billed one.
         guard_ocr_completion!(finish_reason, usage: usage, latency_ms: elapsed)
-        if text.blank?
-          raise Llm::BadResponse.new(
-            "provider returned no OCR text", usage: usage, latency_ms: elapsed,
-            provider: config.provider_name || config.provider_kind.to_s,
-            model: config.api_model_id
-          )
-        end
+        raise billed_ocr_error("provider returned no OCR text", usage: usage, latency_ms: elapsed) if text.blank?
 
         Llm::Result.new(
           text: text,
@@ -107,14 +101,39 @@ module Llm
           provider: config.provider_name || config.provider_kind.to_s,
           usage: usage,
           finish_reason: finish_reason,
-          latency_ms: elapsed_ms(started),
+          latency_ms: elapsed,
           raw: response
         )
       rescue Faraday::Error => e
         raise map_transport_error(e)
       end
 
+      OPENAI_HOST = "api.openai.com".freeze
+      # The gpt-4o family — including the default OCR model, gpt-4o-mini — caps
+      # completions at 16,384 tokens and 400s anything above it. gpt-4.1 and the
+      # reasoning models allow more; declare that in capabilities.max_output_tokens.
+      DEFAULT_OUTPUT_CEILING = 16_384
+
       private
+
+      # Which request field carries the OCR output budget.
+      #
+      # OpenAI deprecated `max_tokens` in favour of `max_completion_tokens` and
+      # its newer models (the o-series, GPT-5) reject the old name outright, so
+      # an OCR assignment to one of those would 400 on every call. Every current
+      # OpenAI model accepts the new name. The wider OpenAI-compatible world has
+      # not caught up uniformly — Ollama only knows `max_tokens`, OpenRouter
+      # varies by route — so anything that is not api.openai.com keeps the name
+      # that is universally understood there. Decided by host, not model id,
+      # because the same model id can be reached through either kind of endpoint.
+      def output_budget_param
+        host = begin
+          URI.parse(config.base_url.to_s).host
+        rescue URI::InvalidURIError
+          nil
+        end
+        host == OPENAI_HOST ? :max_completion_tokens : :max_tokens
+      end
 
       def document_part(doc)
         data_url = "data:#{doc[:content_type]};base64,#{Base64.strict_encode64(doc[:data])}"

--- a/app/services/llm/adapters/openai_compatible.rb
+++ b/app/services/llm/adapters/openai_compatible.rb
@@ -67,31 +67,45 @@ module Llm
       # Document OCR through the chat endpoint with multimodal content parts:
       # images as base64 data-URL image_url parts, PDFs as base64 file parts
       # (gpt-4o/4.1 family). Returns the full extracted text as Result#text.
-      def ocr(documents:, prompt: nil, **_opts)
+      # max_tokens is supplied by OcrStage, sized from the page count. Sending
+      # none left the extraction capped at whatever the endpoint's default
+      # happened to be, which for a multi-page report is a truncation waiting to
+      # happen. `max_tokens` (rather than `max_completion_tokens`) is what every
+      # OpenAI-compatible endpoint this adapter targets understands.
+      def ocr(documents:, prompt: nil, max_tokens: nil, **_opts)
         started = monotonic
         parts = [ { type: "text", text: prompt.to_s } ]
         documents.each { |doc| parts << document_part(doc) }
 
-        response = client.chat(parameters: {
+        params = {
           model: config.api_model_id,
           messages: [ { role: "user", content: parts } ]
-        })
+        }
+        params[:max_tokens] = max_tokens if max_tokens
+        response = client.chat(parameters: params)
         choice = response.dig("choices", 0) || {}
         finish_reason = choice["finish_reason"]
         text = choice.dig("message", "content")
+        usage = usage_from(response["usage"])
+        elapsed = elapsed_ms(started)
 
-        # Same early-stop guard as #structure: a truncated extraction would
-        # silently drop part of a clinical document.
-        if finish_reason && !%w[stop].include?(finish_reason.to_s)
-          raise Llm::BadResponse, "model did not complete (finish_reason=#{finish_reason})"
+        # Shared with the Anthropic adapter (Llm::Adapter#guard_ocr_completion!)
+        # so one rule decides what "complete" means for every vision provider.
+        # Both raises carry the usage: an unusable 200 is still a billed one.
+        guard_ocr_completion!(finish_reason, usage: usage, latency_ms: elapsed)
+        if text.blank?
+          raise Llm::BadResponse.new(
+            "provider returned no OCR text", usage: usage, latency_ms: elapsed,
+            provider: config.provider_name || config.provider_kind.to_s,
+            model: config.api_model_id
+          )
         end
-        raise Llm::BadResponse, "provider returned no OCR text" if text.blank?
 
         Llm::Result.new(
           text: text,
           model: config.api_model_id,
           provider: config.provider_name || config.provider_kind.to_s,
-          usage: usage_from(response["usage"]),
+          usage: usage,
           finish_reason: finish_reason,
           latency_ms: elapsed_ms(started),
           raw: response

--- a/app/services/llm/caller.rb
+++ b/app/services/llm/caller.rb
@@ -32,16 +32,25 @@ module Llm
       raise e unless @config.fallback
 
       rewind_ios(args)
-      result = attempt(@config.fallback, method, *args, **kwargs)
-
       # Carry the abandoned attempt forward instead of dropping it. A truncated
       # or empty 200 is a BILLED response — the provider counted those tokens —
-      # and falling back means the orchestrator only ever sees the success. Left
-      # unattached, the primary's spend is recorded nowhere at all, which is the
-      # exact leak the failed-attempt metering exists to close. Only errors that
-      # actually carry usage are worth passing on; a timeout billed nothing.
-      if result.is_a?(Llm::Result) && e.respond_to?(:billable?) && e.billable?
-        result.discarded_attempts = result.discarded + [ e ]
+      # and falling back means the orchestrator only ever sees the outcome of
+      # the fallback. Left unattached, the primary's spend is recorded nowhere
+      # at all, which is the exact leak the failed-attempt metering exists to
+      # close. It rides on whichever the fallback produces: the Result when it
+      # succeeds, the Error when it fails too — the primary was billed either
+      # way. Only errors that actually carry usage are worth passing on; a
+      # timeout billed nothing.
+      billed = e.respond_to?(:billable?) && e.billable? ? [ e ] : []
+      begin
+        result = attempt(@config.fallback, method, *args, **kwargs)
+      rescue Llm::Error => fallback_error
+        fallback_error.discarded_attempts = fallback_error.discarded + billed if billed.any?
+        raise
+      end
+
+      if result.is_a?(Llm::Result) && billed.any?
+        result.discarded_attempts = result.discarded + billed
       end
       result
     end

--- a/app/services/llm/caller.rb
+++ b/app/services/llm/caller.rb
@@ -32,7 +32,18 @@ module Llm
       raise e unless @config.fallback
 
       rewind_ios(args)
-      attempt(@config.fallback, method, *args, **kwargs)
+      result = attempt(@config.fallback, method, *args, **kwargs)
+
+      # Carry the abandoned attempt forward instead of dropping it. A truncated
+      # or empty 200 is a BILLED response — the provider counted those tokens —
+      # and falling back means the orchestrator only ever sees the success. Left
+      # unattached, the primary's spend is recorded nowhere at all, which is the
+      # exact leak the failed-attempt metering exists to close. Only errors that
+      # actually carry usage are worth passing on; a timeout billed nothing.
+      if result.is_a?(Llm::Result) && e.respond_to?(:billable?) && e.billable?
+        result.discarded_attempts = result.discarded + [ e ]
+      end
+      result
     end
 
     private

--- a/app/services/llm/error.rb
+++ b/app/services/llm/error.rb
@@ -1,5 +1,27 @@
 module Llm
   # Base for all provider-abstraction errors. Adapters rescue transport
   # (Faraday) errors and re-raise these so callers never see provider internals.
-  class Error < StandardError; end
+  #
+  # An error raised AFTER the provider returned a usable-looking 200 — a
+  # truncated extraction, an empty completion — carries that response's usage.
+  # The provider bills for those tokens whether or not we could use the result,
+  # so the attempt is still real spend and the ledger should show it. Transport
+  # failures (timeout, 5xx, connection reset) leave these nil: nothing was
+  # returned, nothing was billed, nothing to record.
+  class Error < StandardError
+    attr_reader :usage, :provider, :model, :latency_ms
+
+    def initialize(message = nil, usage: nil, provider: nil, model: nil, latency_ms: nil)
+      super(message)
+      @usage = usage
+      @provider = provider
+      @model = model
+      @latency_ms = latency_ms
+    end
+
+    # Whether the provider returned something it will charge us for.
+    def billable?
+      !usage.nil?
+    end
+  end
 end

--- a/app/services/llm/error.rb
+++ b/app/services/llm/error.rb
@@ -10,6 +10,13 @@ module Llm
   # returned, nothing was billed, nothing to record.
   class Error < StandardError
     attr_reader :usage, :provider, :model, :latency_ms
+    # Billed errors from EARLIER attempts that Llm::Caller abandoned before this
+    # one was raised — the mirror of Llm::Result#discarded_attempts for the case
+    # where the fallback fails too. Without it, a primary that truncated (billed)
+    # followed by a fallback that 500'd would surface only the fallback error,
+    # and the primary's spend would be recorded nowhere. Set by Llm::Caller;
+    # read by the metering layer, which records each one before this error.
+    attr_accessor :discarded_attempts
 
     def initialize(message = nil, usage: nil, provider: nil, model: nil, latency_ms: nil)
       super(message)
@@ -22,6 +29,11 @@ module Llm
     # Whether the provider returned something it will charge us for.
     def billable?
       !usage.nil?
+    end
+
+    # Always an Array — nil-safe.
+    def discarded
+      Array(discarded_attempts)
     end
   end
 end

--- a/app/services/llm/result.rb
+++ b/app/services/llm/result.rb
@@ -15,6 +15,16 @@ module Llm
     # report one — the ASR stage then falls back to the caller's language hint.
     :language,
     :raw,
+    # Errors from attempts that were abandoned for a fallback provider but which
+    # the provider still billed (a truncated or empty 200 carries usage). Set by
+    # Llm::Caller when it falls back; the metering layer records each one so a
+    # recovered call does not hide the cost of the attempt it recovered from.
+    # Always an Array — nil-safe via #discarded.
+    :discarded_attempts,
     keyword_init: true
-  )
+  ) do
+    def discarded
+      Array(discarded_attempts)
+    end
+  end
 end

--- a/app/services/scribe/ocr_stage.rb
+++ b/app/services/scribe/ocr_stage.rb
@@ -12,9 +12,23 @@ module Scribe
   # the model read off the report.
   class OcrStage
     Result = Struct.new(
-      :text, :pages, :model, :provider, :usage, :raw, :latency_ms,
+      :text, :pages, :model, :provider, :usage, :raw, :latency_ms, :finish_reason,
+      # Billed attempts Llm::Caller abandoned for the fallback provider. Passed
+      # straight through so the orchestrator can meter them; see Llm::Result.
+      :discarded_attempts,
       keyword_init: true
     )
+
+    # Output budget for the transcription, sized from the page count the caller
+    # already measured. The Anthropic adapter's shared DEFAULT_MAX_TOKENS is
+    # 4096 — a STRUCTURING budget, and barely three pages of a dense lab report
+    # — so OCR asks for its own rather than inheriting it. A lab-report page is
+    # roughly 700-1500 tokens of markdown; 2000 leaves headroom for wide tables.
+    # The floor covers an image upload (pages is 1) and the ceiling keeps a
+    # spoofed page count from asking a provider for an absurd completion.
+    TOKENS_PER_PAGE = 2000
+    MIN_MAX_TOKENS = 4096
+    MAX_MAX_TOKENS = 32_000
 
     DEFAULT_PROMPT = <<~PROMPT.freeze
       Transcribe the complete text content of the attached medical document(s)
@@ -29,7 +43,13 @@ module Scribe
 
     # documents: [{ data:, content_type:, filename: }], pages: total page count.
     def call(documents, pages: 0)
-      llm = Llm::Caller.ocr(@config, documents: documents, prompt: DEFAULT_PROMPT)
+      llm = Llm::Caller.ocr(
+        @config,
+        documents: documents,
+        prompt: DEFAULT_PROMPT,
+        max_tokens: max_tokens_for(pages)
+      )
+      guard_completion!(llm)
 
       Result.new(
         text: llm.text,
@@ -38,11 +58,32 @@ module Scribe
         provider: llm.provider,
         usage: usage_with_pages(llm.usage, pages),
         raw: llm.raw,
-        latency_ms: llm.latency_ms
+        latency_ms: llm.latency_ms,
+        finish_reason: llm.finish_reason,
+        discarded_attempts: llm.discarded
       )
     end
 
     private
+
+    # Backstop, not the primary guard. Truncation is caught inside the adapters
+    # (Llm::Adapter#guard_ocr_completion!), because only a raise during the
+    # attempt is visible to Llm::Caller and can therefore spend the fallback
+    # provider. This second check costs nothing and catches a future adapter
+    # that implements #ocr without calling the shared guard — it fails the
+    # session instead of persisting a half-transcribed report, having simply
+    # missed the chance to fall back.
+    def guard_completion!(llm)
+      return if llm.finish_reason.nil? || Llm::Adapter::OCR_COMPLETE.include?(llm.finish_reason.to_s)
+
+      raise Llm::BadResponse,
+            "OCR did not complete (finish_reason=#{llm.finish_reason}); " \
+            "the document was too long for the model's output budget"
+    end
+
+    def max_tokens_for(pages)
+      (pages.to_i * TOKENS_PER_PAGE).clamp(MIN_MAX_TOKENS, MAX_MAX_TOKENS)
+    end
 
     # Adapters normalize token usage but know nothing about page counts; graft
     # the caller-supplied count on so metering prices the per-page component.

--- a/app/services/scribe/orchestrator.rb
+++ b/app/services/scribe/orchestrator.rb
@@ -34,7 +34,7 @@ module Scribe
 
     def call
       transcript = ensure_transcript!
-      return @session if transcript.nil? && asr_failed?
+      return @session if transcript.nil? && transcript_failed?
 
       # Transcript outputs are a pure echo of the already-persisted transcript
       # (no LLM call), so process them FIRST — the transcript reaches :success in
@@ -90,10 +90,103 @@ module Scribe
       else
         transcript_from_whole_file!
       end
-    rescue Llm::Error => e
-      mark_asr_failure!(e)
-      @asr_failed = true
+    # Llm::Error is the EXPECTED failure, but extraction does more than call a
+    # provider: it downloads blobs (ActiveStorage::FileNotFoundError on a purged
+    # or half-written attachment), base64-encodes them, and writes a Transcript
+    # (ActiveRecord::RecordInvalid). Any of those escaping this rescue left every
+    # ScribeOutput sitting at :pending, skipped the webhook, and returned a
+    # :failed session whose `error` was empty — a silent wedge with no client
+    # signal. Everything that can stop a transcript existing is therefore handled
+    # the same way, and the unexpected classes are logged with a backtrace so a
+    # real bug is still diagnosable rather than merely absorbed.
+    rescue StandardError => e
+      meter_failed_attempt(e)
+      mark_transcript_failure!(e, client_message_for(e))
+      @transcript_failed = true
       nil
+    end
+
+    # What the CLIENT is allowed to read about a failure.
+    #
+    # Llm::Error messages are written for this: the adapters deliberately reduce
+    # provider internals to things like "provider request failed (status 502)"
+    # before raising. Everything else reaching the widened rescue is an internal
+    # exception whose message routinely carries SQL and column names
+    # (ActiveRecord::StatementInvalid), bucket names and object keys
+    # (Aws::S3::Errors), or filesystem paths (Errno::*) — and this string is
+    # serialized to the public `errors` key and printed in the playground. That
+    # is CWE-209, and ExceptionHandler already forbids it for controllers.
+    # The real message goes to the log with a backtrace instead.
+    def client_message_for(error)
+      return error.message if error.is_a?(Llm::Error)
+
+      Rails.logger.error(
+        "Scribe::Orchestrator transcript extraction failed for session=#{session.id} " \
+        "modality=#{session.modality}: #{error.class}: #{error.message}\n" \
+        "#{Array(error.backtrace).first(10).join("\n")}"
+      )
+      "transcript extraction failed"
+    end
+
+    # Records provider spend on an attempt we could not use.
+    #
+    # A truncated extraction or an empty completion arrives as a 200: the
+    # provider counted those tokens and will invoice them whether or not the
+    # result was usable. Metering only the successes meant every such attempt —
+    # and every retry of one — was real money absorbed silently, invisible in
+    # both the admin ledger and the usage API.
+    #
+    # Recorded as :failed and deliberately NOT passed to QuotaGuard.deduct!: the
+    # customer is not charged for a run that produced nothing (the UI promises
+    # exactly that), but our own cost stops being invisible. Errors that carry
+    # no usage — a timeout, a 5xx, a connection reset — are skipped, because
+    # nothing was returned and nothing was billed.
+    def meter_failed_attempt(error)
+      return unless error.respond_to?(:billable?) && error.billable?
+
+      function = session.modality_document? ? :ocr : :asr
+      Metering::UsageRecorder.record(
+        account: session.account,
+        function: function,
+        result: Llm::Result.new(
+          usage: usage_for_failed_attempt(error.usage, function),
+          provider: error.provider, model: error.model, latency_ms: error.latency_ms
+        ),
+        api_token: session.api_token,
+        scribe_session: session,
+        status: :failed,
+        # OCR keys by attempt number, so this failure occupies attempt N and a
+        # retry's success takes N+1 — one row per physical attempt, which is the
+        # point. Anything else gets an explicit ":failed" suffix so it can never
+        # occupy the key a later SUCCESS needs: that collision would raise
+        # RecordNotUnique inside the best-effort #meter, skip QuotaGuard.deduct!,
+        # and leave a real charge unbilled and permanently marked failed.
+        dedupe_key: function == :ocr ? dedupe_key_for(:ocr, nil) : "#{session.id}:#{function}:failed"
+      )
+    rescue StandardError => e
+      Rails.logger.error(
+        "Scribe::Orchestrator failed-attempt metering failed for session=#{session.id}: " \
+        "#{e.class}: #{e.message}"
+      )
+      nil
+    end
+
+    # The adapter's usage knows tokens but nothing about pages — OcrStage grafts
+    # the count on, and that only happens on the success path. Without this the
+    # :failed event prices at Llm::Usage's default `pages: 0`, so PriceBook's
+    # per-page component comes out at zero and the failed attempt records only
+    # its token cost. That would hide exactly the quantity the commit hold was
+    # sized on, on the one modality this metering exists for.
+    def usage_for_failed_attempt(usage, function)
+      return usage unless function == :ocr && usage
+
+      Llm::Usage.new(
+        input_tokens: usage.input_tokens,
+        output_tokens: usage.output_tokens,
+        audio_seconds: usage.audio_seconds,
+        pages: session.document_pages,
+        estimated: usage.estimated
+      )
     end
 
     # Runs vision OCR once over all attached documents, persists the extracted
@@ -103,7 +196,11 @@ module Scribe
     def transcript_from_documents!
       config = Llm::ConfigResolver.call(function: :ocr, account: session.account)
 
-      documents = session.document_files.map do |file|
+      # Sorted by attachment id, which is upload order, which is the order the
+      # client intended the report to read in. The association carries no ORDER
+      # BY of its own, so page 3 of a split report could otherwise be transcribed
+      # ahead of page 1 and the extracted text would interleave silently.
+      documents = session.document_files.attachments.sort_by(&:id).map do |file|
         {
           data: file.blob.download,
           content_type: file.blob.content_type,
@@ -123,6 +220,11 @@ module Scribe
         provider: stage.provider,
         model: stage.model
       )
+      # Ordered BEFORE the success so each abandoned attempt takes the lower
+      # attempt number: ocr_attempt_number counts rows already written, so
+      # metering the discard first yields ":ocr:0" for the attempt that failed
+      # and ":ocr:1" for the one that worked, which is the real sequence.
+      Array(stage.discarded_attempts).each { |e| meter_failed_attempt(e) }
       meter(function: :ocr, stage: stage)
       transcript
     end
@@ -185,8 +287,8 @@ module Scribe
       )
     end
 
-    def asr_failed?
-      @asr_failed
+    def transcript_failed?
+      @transcript_failed
     end
 
     def persist_transcript!(asr_result)
@@ -200,14 +302,16 @@ module Scribe
       )
     end
 
-    # ASR is shared: if it fails, no output can be produced. Mark the session and
-    # every output failed and stop.
-    def mark_asr_failure!(error)
+    # The transcript is shared: if it cannot be produced — by ASR, by segment
+    # assembly, or by document OCR — no output can be. Mark the session and every
+    # output failed and stop. Named for the transcript rather than for ASR
+    # because the document modality reaches it too.
+    def mark_transcript_failure!(error, message = error.message)
       session.scribe_outputs.each do |output|
-        output.result_errors = Array(output.result_errors) + [ { message: error.message } ]
+        output.result_errors = Array(output.result_errors) + [ { message: message } ]
         output.update!(status: :failure)
       end
-      session.update!(status: :failed, error: { message: error.message })
+      session.update!(status: :failed, error: { message: message })
     end
 
     # Each output is isolated: a failure sets that output to :failure and pushes
@@ -364,9 +468,28 @@ module Scribe
     def dedupe_key_for(function, scribe_output)
       if scribe_output
         "#{session.id}:#{scribe_output.id}:#{function}"
+      elsif function == :ocr
+        "#{session.id}:ocr:#{ocr_attempt_number}"
       else
         "#{session.id}:#{function}"
       end
+    end
+
+    # OCR is metered once per PHYSICAL attempt, which is the pipeline's stated
+    # metering contract (see this class's header). A re-commit of a failed
+    # document session finds no transcript, runs OCR again, and is charged again
+    # by the provider — but a key of "{session}:ocr" collided with the first
+    # attempt's row on the unique (api_token_id, dedupe_key) index, and the
+    # RecordNotUnique was swallowed by the best-effort #meter. Every retry after
+    # the first was therefore real provider spend billed to nobody.
+    #
+    # Counting prior attempts is safe rather than racy: commit's atomic claim
+    # (only one request may move a session to :processing) makes the orchestrator
+    # single-flight per session. A job retry that re-runs a SETTLED attempt still
+    # short-circuits earlier, at `session.transcript.present?`, so it never
+    # reaches here and cannot double-bill.
+    def ocr_attempt_number
+      session.usage_events.where(function: "ocr").count
     end
 
     # Adapts a stage result struct to the Llm::Result contract the meter reads.

--- a/app/services/scribe/orchestrator.rb
+++ b/app/services/scribe/orchestrator.rb
@@ -142,6 +142,11 @@ module Scribe
     # no usage — a timeout, a 5xx, a connection reset — are skipped, because
     # nothing was returned and nothing was billed.
     def meter_failed_attempt(error)
+      # An error can carry the billed attempts Llm::Caller abandoned before it
+      # (primary truncated, then the fallback failed too). Each is a physical
+      # attempt of its own; recorded FIRST so it takes the lower attempt number,
+      # matching the order the provider actually saw them.
+      error.discarded.each { |earlier| meter_failed_attempt(earlier) } if error.respond_to?(:discarded)
       return unless error.respond_to?(:billable?) && error.billable?
 
       function = session.modality_document? ? :ocr : :asr
@@ -157,11 +162,14 @@ module Scribe
         status: :failed,
         # OCR keys by attempt number, so this failure occupies attempt N and a
         # retry's success takes N+1 — one row per physical attempt, which is the
-        # point. Anything else gets an explicit ":failed" suffix so it can never
-        # occupy the key a later SUCCESS needs: that collision would raise
+        # point. Anything else gets an explicit ":failed:N" suffix so it can
+        # never occupy the key a later SUCCESS needs: that collision would raise
         # RecordNotUnique inside the best-effort #meter, skip QuotaGuard.deduct!,
-        # and leave a real charge unbilled and permanently marked failed.
-        dedupe_key: function == :ocr ? dedupe_key_for(:ocr, nil) : "#{session.id}:#{function}:failed"
+        # and leave a real charge unbilled and permanently marked failed. N
+        # counts the failed rows already written for this function, so a second
+        # billed failure (a re-commit that fails the same way) is a second row
+        # rather than a swallowed RecordNotUnique.
+        dedupe_key: function == :ocr ? dedupe_key_for(:ocr, nil) : failed_dedupe_key_for(function)
       )
     rescue StandardError => e
       Rails.logger.error(
@@ -490,6 +498,14 @@ module Scribe
     # reaches here and cannot double-bill.
     def ocr_attempt_number
       session.usage_events.where(function: "ocr").count
+    end
+
+    # Key for a billed-but-unusable attempt of a function that is not metered
+    # per attempt (ASR today). Suffixed with the number of failed rows already
+    # written for that function so repeated failures each get their own row.
+    def failed_dedupe_key_for(function)
+      failed = session.usage_events.where(function: function.to_s, status: "failed").count
+      "#{session.id}:#{function}:failed:#{failed}"
     end
 
     # Adapts a stage result struct to the Llm::Result contract the meter reads.

--- a/app/services/scribe/session_token.rb
+++ b/app/services/scribe/session_token.rb
@@ -4,7 +4,13 @@ module Scribe
   # revocation rides on the short TTL and the session's own expiry/status.
   module SessionToken
     PREFIX = "mss_"
-    SCOPE = %w[audio read].freeze
+    # The routes a scoped token may reach. Nothing reads this claim yet — the
+    # actual boundary is `sid`, enforced in ScribeSessionsController#find_session,
+    # plus `require_account_token!` on the account-wide actions. It is listed
+    # honestly all the same: a document session's client uploads to /documents,
+    # and a scope that said "audio" while permitting documents would be a trap
+    # for whoever implements enforcement.
+    SCOPE = %w[audio document read].freeze
     DEFAULT_TTL = 15.minutes
 
     module_function

--- a/app/views/playground/_result.html.erb
+++ b/app/views/playground/_result.html.erb
@@ -6,7 +6,11 @@
   Usage is shown deliberately: the person evaluating whether this product is
   worth paying for is the person who just pressed record.
 %>
-<% total_cost = session.usage_events.sum { |event| event.cost.to_f } %>
+<%# Finalized only, like the per-stage rows below and the API's usage object:
+    a billed-but-unusable attempt (a truncated OCR response) is in the ledger
+    as :failed for our own accounting but was never charged to the customer,
+    and the status line has just told them a failed run costs nothing. %>
+<% total_cost = session.usage_events.select(&:finalized?).sum { |event| event.cost.to_f } %>
 <% audio_seconds = session.usage_events.sum { |event| event.audio_seconds.to_f } %>
 <% total_tokens = session.usage_events.sum { |event| event.total_tokens.to_i } %>
 <% filled = outputs.sum { |output| output.result.is_a?(Hash) ? output.result.count { |_, v| v.present? || v == false } : 0 } %>

--- a/app/views/playground/show.html.erb
+++ b/app/views/playground/show.html.erb
@@ -2,7 +2,7 @@
 
 <%= render "shared/page_header",
       title: "Try #{@template.name}",
-      subtitle: "Record the way your users will. This runs a real session against this template — same models, same latency, same cost." do %>
+      subtitle: "Record the way your users will, or upload a lab report. This runs a real session against this template — same models, same latency, same cost." do %>
   <%= link_to "Back to template", template_path(@template), class: "btn btn-white" %>
 <% end %>
 
@@ -27,9 +27,36 @@
        data-playground-api-base-value="/api/v2"
        data-playground-vad-base-value="/vad/0.0.24/"
        data-playground-ort-base-value="/vad/0.0.24/ort/"
+       <%#
+         Rendered from the model constants so the browser can refuse a file the
+         server would refuse anyway — locally, before spending the upload. A
+         courtesy, not the boundary: #documents re-checks every one of these
+         under a row lock, and counts pages, which the browser cannot.
+       %>
+       data-playground-max-file-bytes-value="<%= ScribeSession::MAX_DOCUMENT_FILE_BYTES %>"
+       data-playground-max-total-bytes-value="<%= ScribeSession::MAX_DOCUMENT_BYTES %>"
+       data-playground-document-types-value="<%= ScribeSession::ALLOWED_DOCUMENT_TYPES.to_json %>"
        class="space-y-6">
 
-    <%# ── Recorder ─────────────────────────────────────────────────────── %>
+    <%#
+      Two ways in, one pipeline. A recording and an uploaded lab report differ
+      only in how the transcript comes to exist — after that both run the same
+      structuring, metering and polling — so the two live in ONE card behind a
+      mode switch rather than on separate screens. The status line, step badges
+      and error panel below are shared by both for the same reason.
+    %>
+    <div class="pg-modes" role="tablist" aria-label="Source">
+      <button type="button" role="tab" aria-selected="true"
+              data-playground-target="modeAudio"
+              data-action="playground#useAudio"
+              class="pg-mode pg-mode-on">Record audio</button>
+      <button type="button" role="tab" aria-selected="false"
+              data-playground-target="modeDocument"
+              data-action="playground#useDocument"
+              class="pg-mode">Upload a report</button>
+    </div>
+
+    <%# ── Source: record, or upload ────────────────────────────────────── %>
     <section class="card card-pad">
       <div class="flex flex-wrap items-center gap-5">
         <%#
@@ -56,6 +83,19 @@
           </span>
         </button>
 
+        <%# The document twin of the orb: same 64px footprint, same slot. %>
+        <button type="button"
+                data-playground-target="pick"
+                data-action="playground#chooseFiles"
+                class="pg-orb pg-orb-idle hidden"
+                aria-label="Choose a document">
+          <svg class="pg-icon pg-icon-doc" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M14 2H7a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V7z"/>
+            <path d="M14 2v5h5M9 13h6M9 17h4"/>
+          </svg>
+          <span class="pg-arc" aria-hidden="true"></span>
+        </button>
+
         <div class="min-w-0 flex-1">
           <p data-playground-target="statusLabel" class="text-base font-semibold text-gray-900">
             Ready when you are
@@ -65,20 +105,40 @@
           </p>
 
           <div data-playground-target="steps" class="mt-3 hidden flex-wrap items-center gap-2">
-            <span class="badge badge-neutral" data-step="0">Transcribing</span>
+            <span class="badge badge-neutral" data-step="0" data-playground-target="stepZero">Transcribing</span>
             <span class="badge badge-neutral" data-step="1">Extracting details</span>
             <span class="badge badge-neutral" data-step="2">Filling form</span>
           </div>
         </div>
 
-        <div class="flex items-center gap-3">
+        <div data-playground-target="audioControls" class="flex items-center gap-3">
           <span data-playground-target="timer" class="num hidden text-2xl font-semibold tabular-nums text-gray-900">0:00</span>
           <button type="button"
                   data-playground-target="pause"
                   data-action="playground#togglePause"
                   class="btn btn-white btn-small hidden">Pause</button>
         </div>
+
+        <div data-playground-target="documentControls" class="hidden items-center gap-3">
+          <%#
+            accept is a courtesy filter in the file dialog; ALLOWED_DOCUMENT_TYPES
+            on the server is the actual gate. `multiple` because a report is
+            routinely a page per photo — they upload in order and are OCR'd as
+            one document.
+          %>
+          <input type="file" class="sr-only"
+                 data-playground-target="fileInput"
+                 data-action="playground#filesChosen"
+                 accept="application/pdf,image/jpeg,image/png,image/webp"
+                 multiple>
+          <button type="button"
+                  data-playground-target="extract"
+                  data-action="playground#extract"
+                  class="btn btn-primary" disabled>Extract</button>
+        </div>
       </div>
+
+      <ul data-playground-target="fileList" class="mt-5 hidden space-y-2"></ul>
 
       <div data-playground-target="error" class="mt-5 hidden rounded-xl border border-rose-200 bg-rose-50 px-4 py-3">
         <p class="text-sm text-rose-800" data-playground-target="errorMessage"></p>
@@ -89,10 +149,10 @@
       </div>
     </section>
 
-    <%# ── Transcript ───────────────────────────────────────────────────── %>
+    <%# ── Transcript / extracted text ──────────────────────────────────── %>
     <section data-playground-target="transcriptCard" class="card hidden">
       <div class="card-header flex items-center justify-between gap-2">
-        <h2 class="text-sm font-semibold text-gray-900">Transcript</h2>
+        <h2 data-playground-target="transcriptTitle" class="text-sm font-semibold text-gray-900">Transcript</h2>
         <span data-playground-target="transcriptBadge" class="badge badge-progress">Listening</span>
       </div>
       <div class="card-pad">

--- a/app/views/playground/show.html.erb
+++ b/app/views/playground/show.html.erb
@@ -1,4 +1,13 @@
 <% content_for :title, "Try #{@template.name}" %>
+<%#
+  Never restored from Turbo's snapshot cache. This page holds live state — a
+  microphone, a session being billed, a chosen file, a run in flight — none of
+  which survives a navigation, while the snapshot would faithfully restore the
+  DOM that described it. connect() resets the controller to idle/audio, so a
+  Back-button restoration would otherwise show the upload UI while the
+  controller creates audio sessions and every Extract 409s. Fetch fresh instead.
+%>
+<% content_for :head, tag.meta(name: "turbo-cache-control", content: "no-cache") %>
 
 <%= render "shared/page_header",
       title: "Try #{@template.name}",
@@ -45,12 +54,18 @@
       mode switch rather than on separate screens. The status line, step badges
       and error panel below are shared by both for the same reason.
     %>
-    <div class="pg-modes" role="tablist" aria-label="Source">
-      <button type="button" role="tab" aria-selected="true"
+    <%#
+      A group of toggle buttons (aria-pressed), not a tablist: tabs promise
+      panels, aria-controls and arrow-key navigation, none of which apply to a
+      switch that changes what one shared card does. Two focusable buttons is
+      the honest description of this control.
+    %>
+    <div class="pg-modes" role="group" aria-label="Source">
+      <button type="button" aria-pressed="true"
               data-playground-target="modeAudio"
               data-action="playground#useAudio"
               class="pg-mode pg-mode-on">Record audio</button>
-      <button type="button" role="tab" aria-selected="false"
+      <button type="button" aria-pressed="false"
               data-playground-target="modeDocument"
               data-action="playground#useDocument"
               class="pg-mode">Upload a report</button>

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -9,5 +9,10 @@ Rails.application.config.filter_parameters += [
   # The chunked and segmented upload paths carry the same recorded speech as
   # :audio under different param names, so they need the same treatment — an
   # unfiltered :segment writes PHI straight to the Rails log.
-  :segment, :chunk
+  :segment, :chunk,
+  # The OCR modality's upload param. An uploaded file logs as its
+  # original_filename, and lab reports are named after the patient far more
+  # often than not ("ramesh-kumar-cbc-2026-08.pdf"), so leaving :document
+  # unfiltered writes identifiers into every request line.
+  :document
 ]

--- a/config/initializers/pdf_reader_inflate_cap.rb
+++ b/config/initializers/pdf_reader_inflate_cap.rb
@@ -1,0 +1,67 @@
+# Bounds how much a single FlateDecode stream inside a PDF may inflate to.
+#
+# pdf-reader inflates every compressed stream it touches with
+# `Zlib::Inflate.new(...).inflate(data)` — the one-shot form, which returns the
+# ENTIRE inflated output as one String with no cap. Deflate compresses runs of
+# identical bytes ~1000:1, and filters chain (`/Filter [/FlateDecode
+# /FlateDecode]`), so a 4 KB upload can be a few gigabytes once decoded.
+# PDF::Reader.new eagerly parses the xref (which may itself be a compressed
+# `/Type /XRef` stream) in its constructor, and the page-tree walk in
+# Api::V2::ScribeSessionsController#count_pages then reads object streams —
+# every one of those inflates go through the code below.
+#
+# The request-thread Timeout around count_pages bounds wall-clock, not
+# allocation: measured, a 3.6 KB bomb reached 2 GB of RSS in 0.7 s and the
+# process was OOM-killed (prod web instances are 1 GB) before the 2 s timer
+# could fire. No rescue can catch a kernel OOM kill; the allocation has to be
+# prevented. So the inflate is switched to the streaming block form, which
+# yields output a chunk at a time, and the stream is abandoned the moment its
+# output passes MAX_INFLATED_BYTES — raising PDF::Reader::MalformedPDFError,
+# which is a StandardError the existing `rescue` in count_pages already turns
+# into the same clean 422 any other unreadable PDF gets.
+#
+# The cap is per inflate call. Page counting only needs the xref and the
+# object streams that hold page dictionaries — kilobytes for a real report and
+# well under a megabyte even for a very large document — so 16 MB is generous
+# headroom for anything legitimate and still ~64x under the 1 GB the process
+# has to live in.
+#
+# The override keeps the gem's own two-attempt semantics: try zlib/gzip
+# auto-detect first, then raw deflate on a Zlib::Error, and return nil when
+# neither works so Filter::Flate#filter can retry with the trailing byte
+# dropped and finally raise its own MalformedPDFError. Only the cap escapes.
+module PdfReaderInflateCap
+  MAX_INFLATED_BYTES = 16.megabytes
+
+  private
+
+  def zlib_inflate(data)
+    [ self.class::ZLIB_AUTO_DETECT_ZLIB_OR_GZIP, self.class::ZLIB_RAW_DEFLATE ].each do |window_bits|
+      inflated = bounded_inflate(data, window_bits)
+      return inflated if inflated
+    end
+    nil
+  end
+
+  def bounded_inflate(data, window_bits)
+    inflater = Zlib::Inflate.new(window_bits)
+    out = +""
+    inflater.inflate(data) do |chunk|
+      out << chunk
+      if out.bytesize > MAX_INFLATED_BYTES
+        raise PDF::Reader::MalformedPDFError,
+              "compressed stream inflates past #{MAX_INFLATED_BYTES} bytes"
+      end
+    end
+    out
+  rescue Zlib::Error
+    # Not this container format (or corrupt); the caller tries the next one.
+    nil
+  ensure
+    # Safe on an interrupted stream; releases the zlib window now rather than
+    # at GC, which matters when a hostile file makes this loop dozens of times.
+    inflater&.close
+  end
+end
+
+PDF::Reader::Filter::Flate.prepend(PdfReaderInflateCap)

--- a/db/migrate/20260817090000_constrain_document_pages.rb
+++ b/db/migrate/20260817090000_constrain_document_pages.rb
@@ -1,0 +1,46 @@
+# A database-side backstop for ScribeSession::MAX_DOCUMENT_PAGES.
+#
+# The page ceiling is what sizes the OCR request and the per-page credit hold at
+# commit, and until now it was enforced only by an unlocked read-check-write in
+# Api::V2::ScribeSessionsController#documents. That check is now taken under a
+# row lock, but a lock only binds code that remembers to take it — a console
+# session, a future write path, or a bulk update can still push the counter past
+# the cap. This makes the invariant true of the column itself.
+#
+# Any row already over the cap is clamped FIRST, deliberately. `NOT VALID` skips
+# the historical scan but still enforces on every subsequent INSERT and UPDATE,
+# whatever columns it touches — so an untouched over-cap row would become
+# permanently unwritable, and the very next `status` update (commit's atomic
+# claim, or the orchestrator's rollup) would raise CheckViolation and 500 the
+# session forever. Leaving the constraint unvalidated without clamping trades a
+# silent cap breach for a hard outage on exactly the affected rows.
+#
+# Clamping is safe for billing: the billed page quantity lives in
+# usage_events.pages, an immutable per-attempt ledger. scribe_sessions.document_pages
+# is only the running counter the caps and the hold are computed from, so
+# correcting it rewrites no charge that was ever made.
+#
+# The literal 20 is deliberately duplicated from ScribeSession::MAX_DOCUMENT_PAGES
+# rather than interpolated: a migration must keep meaning what it meant on the
+# day it ran, even after the constant moves.
+class ConstrainDocumentPages < ActiveRecord::Migration[8.1]
+  CAP = 20
+
+  def up
+    over = execute("SELECT count(*) FROM scribe_sessions WHERE document_pages > #{CAP}")
+             .first.fetch("count").to_i
+    if over.positive?
+      say "clamping #{over} scribe_sessions row(s) with document_pages > #{CAP}"
+      execute "UPDATE scribe_sessions SET document_pages = #{CAP} WHERE document_pages > #{CAP}"
+    end
+
+    add_check_constraint :scribe_sessions,
+                         "document_pages >= 0 AND document_pages <= #{CAP}",
+                         name: "scribe_sessions_document_pages_within_cap",
+                         validate: false
+  end
+
+  def down
+    remove_check_constraint :scribe_sessions, name: "scribe_sessions_document_pages_within_cap"
+  end
+end

--- a/db/migrate/20260817090000_constrain_document_pages.rb
+++ b/db/migrate/20260817090000_constrain_document_pages.rb
@@ -27,11 +27,20 @@ class ConstrainDocumentPages < ActiveRecord::Migration[8.1]
   CAP = 20
 
   def up
+    # Both edges of the constraint, not just the cap: a negative counter (only
+    # reachable by a bad manual write, but the constraint below would make it
+    # permanently unwritable all the same) is clamped to zero.
     over = execute("SELECT count(*) FROM scribe_sessions WHERE document_pages > #{CAP}")
              .first.fetch("count").to_i
     if over.positive?
       say "clamping #{over} scribe_sessions row(s) with document_pages > #{CAP}"
       execute "UPDATE scribe_sessions SET document_pages = #{CAP} WHERE document_pages > #{CAP}"
+    end
+    under = execute("SELECT count(*) FROM scribe_sessions WHERE document_pages < 0")
+              .first.fetch("count").to_i
+    if under.positive?
+      say "clamping #{under} scribe_sessions row(s) with document_pages < 0"
+      execute "UPDATE scribe_sessions SET document_pages = 0 WHERE document_pages < 0"
     end
 
     add_check_constraint :scribe_sessions,

--- a/db/migrate/20260817093000_index_usage_events_on_scribe_session.rb
+++ b/db/migrate/20260817093000_index_usage_events_on_scribe_session.rb
@@ -1,0 +1,14 @@
+# usage_events is read by scribe_session_id on every poll of a session (the
+# serializer's per-session usage block), by the playground result page, and now
+# by the orchestrator when it numbers OCR attempts and keys failed ones — yet
+# the column carried no index, so each of those was a sequential scan of the
+# whole ledger. Cheap while the table is small; a real cost the moment it isn't,
+# on the hottest read path a client has.
+#
+# A plain (non-concurrent) add_index: the table is a few hundred rows today, so
+# the write lock lasts milliseconds and the migration stays transactional.
+class IndexUsageEventsOnScribeSession < ActiveRecord::Migration[8.1]
+  def change
+    add_index :usage_events, :scribe_session_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_17_090000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_17_093000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -349,6 +349,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_17_090000) do
     t.index ["account_id"], name: "index_usage_events_on_account_id"
     t.index ["api_token_id", "dedupe_key"], name: "index_usage_events_on_token_and_dedupe_key", unique: true
     t.index ["api_token_id"], name: "index_usage_events_on_api_token_id"
+    t.index ["scribe_session_id"], name: "index_usage_events_on_scribe_session_id"
     t.index ["status", "reserved_until"], name: "index_usage_events_on_status_and_reserved_until"
     t.index ["user_id", "created_at"], name: "index_usage_events_on_user_id_and_created_at"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_16_110000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_17_090000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -267,6 +267,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_16_110000) do
     t.index ["api_token_id"], name: "index_scribe_sessions_on_api_token_id"
     t.index ["user_id"], name: "index_scribe_sessions_on_user_id"
   end
+
+  add_check_constraint "scribe_sessions", "document_pages >= 0 AND document_pages <= 20", name: "scribe_sessions_document_pages_within_cap", validate: false
 
   create_table "scribe_transcript_segments", force: :cascade do |t|
     t.string "content_type"

--- a/docs/api/v2.md
+++ b/docs/api/v2.md
@@ -182,29 +182,57 @@ audio blob.
 
 ### POST /api/v2/scribe_sessions/:id/documents — upload a document (OCR)
 
-For sessions created with `"modality": "document"`. Attaches one lab-report
+For sessions created with `"modality": "document"`. Attaches **one** lab-report
 document (multipart field `document`) and moves the session to `uploading`.
-Allowed types: `application/pdf`, `image/jpeg`, `image/png`, `image/webp`;
-10 MB per file, 20 MB and 20 pages per session. PDF pages are counted at
-upload (an image counts as one page); an encrypted or malformed PDF is a
-clean **422**.
 
-At commit, a vision model extracts the complete document text (the session's
-`transcript` — the audit trail of what the model read), then the declared
-outputs are structured from that text exactly as for audio.
+**Limits**, all enforced server-side under a row lock, so concurrent uploads
+cannot slip past them:
+
+| Limit | Value |
+| --- | --- |
+| Content types | `application/pdf`, `image/jpeg`, `image/png`, `image/webp` |
+| Per file | 10 MB |
+| Per session | 20 MB, 20 pages |
+
+Pages are counted at upload time by walking the PDF's page tree — not by
+trusting its self-declared `/Count`, which a file can understate. An image
+counts as one page. An encrypted, malformed, or hostile PDF is a clean **422**
+rather than a slow failure at commit. The response's `pages` is the running
+session total, so it is also the quantity your per-page cost is based on.
+
+**Multiple files are one document.** Call this endpoint once per file, *in
+order and sequentially* — a report photographed a page at a time is transcribed
+in upload order. Racing the calls is safe but shuffles the pages.
+
+At commit, a vision model extracts the complete document text in a single call
+across every attached file. That text is persisted as the session's
+`transcript` — the audit trail of what the model actually read — and the
+declared outputs are then structured from it exactly as for audio. An
+extraction that hits the model's output budget is a **failure**, never a
+truncated transcript: a partial lab report that reads as complete is worse than
+no result. Re-commit to retry it.
 
 **Responses**
 
 - **200 OK** — `{ "id": <id>, "status": "uploading", "pages": <running total> }`.
-- **409 validation_error** — uploading a document to an `audio` session (and
-  vice versa: audio endpoints 409 on a `document` session).
-- **422 validation_error / document_upload_failed** — bad type, size, page cap,
-  or unreadable PDF.
+- **404 session_not_found** — unknown id (or another account's id).
+- **409 validation_error** — the session's modality is `audio` (and vice versa:
+  the audio endpoints 409 on a `document` session), or its status is past
+  `uploading`.
+- **410 session_expired** — the session has passed `expires_at`.
+- **422 validation_error** — missing `document` field, unsupported content type,
+  or a PDF that could not be read.
+- **422 document_upload_failed** — over the per-file, per-session byte, or page
+  ceiling. The upload is rejected whole; the session's `pages` does not move.
 
 ```bash
 curl -X POST https://api.medispeak.example/api/v2/scribe_sessions/1001/documents \
   -H "Authorization: Bearer $MSK_TOKEN" \
   -F "document=@lab_report.pdf"
+```
+
+```json
+{ "id": 1001, "status": "uploading", "pages": 3 }
 ```
 
 ---
@@ -362,11 +390,30 @@ Optional params (all backward compatible):
   "id": 1001,
   "status": "completed",
   "mode": "consultation",
+  "modality": "document",
   "language": "en",
+  "created_at": "2026-06-26T09:00:00.000Z",
   "expires_at": "2026-06-26T10:00:00.000Z",
-  "outputs": [ <output>, ... ]
+  "transcript": { "text": "Hemoglobin | 13.5 | g/dL | 12–16", "language": "en" },
+  "outputs": [ <output>, ... ],
+  "usage": {
+    "cost": 0.0142,
+    "total_tokens": 1320,
+    "audio_seconds": 0.0,
+    "pages": 3,
+    "by_function": { "ocr": 0.0121, "structuring": 0.0021 }
+  }
 }
 ```
+
+| Field | Description |
+| --- | --- |
+| `modality` | `audio` or `document`. Fixed at creation. |
+| `transcript` | The extracted source text — OCR output for a `document` session, ASR output for an `audio` one — as `{ text, language }`, or `null` before it exists. **This is the top-level way to read OCR output**; it does not depend on having declared a `transcript` output. During an audio recording it carries the growing live transcript instead. |
+| `usage` | Per-session metering. `pages` is the quantity OCR is billed on; `audio_seconds` is the audio equivalent, and each is `0` for the other modality. `by_function` splits cost across `ocr` / `asr` / `structuring`. |
+
+Failed attempts appear in the ledger but are **not** charged to your credits, so
+a run that produced nothing costs you nothing.
 
 ### Output object
 
@@ -564,4 +611,36 @@ curl -s -X POST "$BASE/api/v2/scribe_sessions/$ID/commit" \
 # 4. Poll until 200/206 (HTTP 202 means still processing)
 curl -s -i "$BASE/api/v2/scribe_sessions/$ID" \
   -H "Authorization: Bearer $MSK_TOKEN"
+```
+
+### Document (OCR) flow
+
+Identical apart from steps 1 and 2: declare `"modality": "document"` at create,
+and upload files instead of audio. Commit, polling, output shapes and billing
+are the same path.
+
+```bash
+# 1. Create a document session
+SESSION=$(curl -s -X POST "$BASE/api/v2/scribe_sessions" \
+  -H "Authorization: Bearer $MSK_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Idempotency-Key: $(uuidgen)" \
+  -d '{"modality":"document","outputs":[{"type":"form","page_id":42}]}')
+ID=$(echo "$SESSION" | jq -r .id)
+
+# 2. Upload each file, one call each, IN PAGE ORDER and sequentially
+for f in page1.jpg page2.jpg page3.jpg; do
+  curl -s -X POST "$BASE/api/v2/scribe_sessions/$ID/documents" \
+    -H "Authorization: Bearer $MSK_TOKEN" \
+    -F "document=@$f"
+done
+
+# 3 & 4. Commit and poll, exactly as above. The extracted text arrives as
+#        the session's top-level `transcript`.
+curl -s -X POST "$BASE/api/v2/scribe_sessions/$ID/commit" \
+  -H "Authorization: Bearer $MSK_TOKEN" \
+  -H "Idempotency-Key: $(uuidgen)"
+
+curl -s "$BASE/api/v2/scribe_sessions/$ID" \
+  -H "Authorization: Bearer $MSK_TOKEN" | jq '.transcript, .outputs'
 ```

--- a/docs/api/v2.md
+++ b/docs/api/v2.md
@@ -194,9 +194,11 @@ cannot slip past them:
 | Per file | 10 MB |
 | Per session | 20 MB, 20 pages |
 
-Pages are counted at upload time by walking the PDF's page tree — not by
-trusting its self-declared `/Count`, which a file can understate. An image
-counts as one page. An encrypted, malformed, or hostile PDF is a clean **422**
+Pages are counted at upload time by walking the PDF's page tree, so a file
+cannot understate itself through its self-declared `/Count`; if `/Count`
+claims *more* pages than the tree holds, the larger number is used, so an
+inconsistent file is never billed for less than it declares. An image counts
+as one page. An encrypted, malformed, or hostile PDF is a clean **422**
 rather than a slow failure at commit. The response's `pages` is the running
 session total, so it is also the quantity your per-page cost is based on.
 
@@ -221,9 +223,10 @@ no result. Re-commit to retry it.
   `uploading`.
 - **410 session_expired** — the session has passed `expires_at`.
 - **422 validation_error** — missing `document` field, unsupported content type,
-  or a PDF that could not be read.
-- **422 document_upload_failed** — over the per-file, per-session byte, or page
-  ceiling. The upload is rejected whole; the session's `pages` does not move.
+  a single file over the 10 MB per-file limit, or a PDF that could not be read.
+- **422 document_upload_failed** — the upload would take the session over its
+  cumulative byte or page ceiling. The upload is rejected whole; the session's
+  `pages` does not move.
 
 ```bash
 curl -X POST https://api.medispeak.example/api/v2/scribe_sessions/1001/documents \
@@ -412,8 +415,11 @@ Optional params (all backward compatible):
 | `transcript` | The extracted source text — OCR output for a `document` session, ASR output for an `audio` one — as `{ text, language }`, or `null` before it exists. **This is the top-level way to read OCR output**; it does not depend on having declared a `transcript` output. During an audio recording it carries the growing live transcript instead. |
 | `usage` | Per-session metering. `pages` is the quantity OCR is billed on; `audio_seconds` is the audio equivalent, and each is `0` for the other modality. `by_function` splits cost across `ocr` / `asr` / `structuring`. |
 
-Failed attempts appear in the ledger but are **not** charged to your credits, so
-a run that produced nothing costs you nothing.
+Failed attempts (a provider response that was billed but could not be used —
+a truncated extraction, say) are kept in the account ledger for our own
+accounting but are **not** charged to your credits and **not** included in this
+`usage` object, so a run that produced nothing costs you nothing and reads that
+way.
 
 ### Output object
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -76,8 +76,11 @@ callers. When a provider omits a usage block, the adapter returns a `Usage` with
      naming the unsettled seqs** — re-commit retries exactly those segments.
    - `audio` **without** segments → whole-file ASR (`AsrStage`).
    The extracted text persists as the session's `Transcript`. If extraction
-   fails, the session and **every** output are marked failed and it returns
-   early (nothing to structure).
+   fails — for **any** reason, not only an `Llm::Error`: a missing blob, a
+   rejected `Transcript` write — the session and **every** output are marked
+   failed and it returns early (nothing to structure). Widening that rescue is
+   what keeps a lost blob from leaving outputs stuck at `pending` with no
+   webhook and no error text.
 2. **Per output, isolated** — for each `scribe_output`:
    - `transcript` → echo the transcript text/language (no LLM call).
    - `form` → run `StructuringStage` against the page's form fields. Valid →
@@ -92,6 +95,57 @@ callers. When a provider omits a usage block, the adapter returns a `Usage` with
 Metering for each physical attempt runs **outside** the per-output rescue so a
 metering error can never demote a finalized success or fail the session.
 
+### The document (OCR) modality
+
+A `document` session differs from an `audio` one in exactly one place — how the
+`Transcript` comes to exist. Everything downstream (structuring, per-output
+isolation, metering, status rollup, webhooks) is the shared path, which is the
+whole reason OCR was modelled as a transcript-producing stage rather than a
+parallel pipeline.
+
+```
+POST /:id/documents  (one call per file, in page order)
+  │  content-type allowlist + 10 MB per file
+  │  count_pages: walk the PDF /Pages tree — NOT its self-declared /Count —
+  │               inside a 2s Timeout, because both the xref subsection length
+  │               and the tree are attacker-controlled
+  │  session.with_lock { re-check 20 MB / 20 pages, attach, increment }
+  ▼
+POST /:id/commit → hold sized from pages → ProcessScribeSessionJob
+  ▼
+Orchestrator#transcript_from_documents!
+  │  attachments sorted by id (= upload order = reading order)
+  │  each blob downloaded and base64'd; ONE provider call carries them all
+  ▼
+Scribe::OcrStage
+  │  max_tokens sized from the page count (2000/page, floored and capped) —
+  │  the adapters' 4096 default is a structuring budget and truncates a report
+  │  Llm::Caller.ocr → primary, then fallback on a TRANSIENT error
+  ▼
+Transcript (the audit trail of what the model read) → StructuringStage per output
+```
+
+**Completeness is enforced, not assumed.** `Llm::Adapter#guard_ocr_completion!`
+rejects any finish reason other than `stop`/`end_turn`, so a response that ran
+out of output budget fails instead of persisting half a lab report that reads
+as complete. It is raised *inside* the adapter deliberately: only an error
+raised during the attempt is visible to `Llm::Caller`, which is what turns a
+truncation into a fallback attempt rather than an immediate session failure.
+`OcrStage` repeats the check as a backstop for any future adapter that forgets.
+
+**Billed-but-unusable attempts are recorded.** A truncated or empty completion
+still consumed tokens the provider will invoice, so `Llm::Error` carries that
+response's `usage` and the orchestrator writes a `status: :failed` `UsageEvent`
+for it — visible in the ledger, deliberately **not** passed to
+`QuotaGuard.deduct!`, since the customer is not charged for a run that produced
+nothing. Transport failures carry no usage and record nothing.
+
+**Retries are billed.** The OCR dedupe key carries an attempt number, so
+re-committing a session whose extraction failed meters the second provider call
+separately instead of colliding with the first and vanishing. Single-flight is
+guaranteed by commit's atomic claim; a retry of an attempt that already
+*succeeded* short-circuits earlier, at `session.transcript.present?`.
+
 ---
 
 ## The meter: `Metering::*`
@@ -100,7 +154,7 @@ metering error can never demote a finalized success or fail the session.
 
 | Component                  | Responsibility |
 |----------------------------|----------------|
-| `Metering::UsageRecorder`  | Pure per-attempt meter. From a normalized `Llm::Result` it prices the call via `PriceBook`, snapshots unit prices, attributes the acting `user_id`, and persists a `UsageEvent`. **One metering rule:** every successful physical attempt records exactly one dedupe-keyed `UsageEvent`; assembly and echo are never metered. |
+| `Metering::UsageRecorder`  | Pure per-attempt meter. From a normalized `Llm::Result` it prices the call via `PriceBook`, snapshots unit prices, attributes the acting `user_id`, and persists a `UsageEvent`. **One metering rule:** every physical attempt records exactly one dedupe-keyed `UsageEvent` — `finalized` when it produced a usable result, `failed` when the provider billed us for one we could not use (a truncated or empty completion). Only `finalized` events are deducted from credits. Attempts that returned nothing at all (timeouts, 5xx) and steps with no provider call (segment assembly, transcript echo) are never metered. |
 | `Metering::PriceBook`      | Computes cost from versioned `ModelPrice` (per-million tokens), `AudioModelPrice` (per-minute), and `DocumentModelPrice` (per-page, optional) tables, effective at a timestamp. Never raises on a missing price — it returns zeros so metering degrades gracefully. |
 | `Metering::QuotaGuard`     | Ledger-backed quota enforcement against `AccountCredit` + `CreditTransaction`: `hold!` (at commit), `deduct!` (on finalize), `refund!`. Accounts without an `AccountCredit` are treated as unlimited (no-ops). |
 | `Metering::LimitGuard`     | Pure-read admission gate for `UsageLimit` caps (subtree/per_user × tokens/cost × daily/monthly). Windowed sums over `usage_events`; every limit on the account's leaf-to-root chain must pass at commit. NOT a second ledger. |
@@ -116,6 +170,8 @@ Client ──Bearer msk_live_…──► Api::V2::ScribeSessionsController
   │
   │  POST /scribe_sessions      create the session + outputs        ► 201
   │  POST /:id/audio            attach audio blob (status: uploading)► 200
+  │    …or, modality: document…
+  │  POST /:id/documents        count pages, attach under a row lock ► 200
   │  POST /:id/commit ──────────┐
   │                             │  QuotaGuard.hold!(estimate: 0)
   │                             │  session → processing
@@ -125,9 +181,12 @@ Client ──Bearer msk_live_…──► Api::V2::ScribeSessionsController
   │                             │  session → processing
   │                             ▼
   │                 Scribe::Orchestrator
-  │                   │  ensure_transcript!  (ASR once → Transcript)
-  │                   │     └─ Llm::ConfigResolver(:asr) → AsrStage → Llm::Caller.transcribe
+  │                   │  ensure_transcript!  (source extracted ONCE → Transcript)
+  │                   │     └─ audio:    ConfigResolver(:asr) → AsrStage → Caller.transcribe
+  │                   │     └─ document: ConfigResolver(:ocr) → OcrStage → Caller.ocr
   │                   │     └─ UsageRecorder.record + QuotaGuard.deduct!   (per attempt)
+  │                   │     └─ on a billed-but-unusable response:
+  │                   │          UsageRecorder.record(status: :failed), NO deduct
   │                   │  for each output:
   │                   │     └─ StructuringStage → Llm::Caller.structure → SchemaValidator
   │                   │     └─ UsageRecorder.record + QuotaGuard.deduct!   (per attempt)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -108,7 +108,9 @@ POST /:id/documents  (one call per file, in page order)
   │  content-type allowlist + 10 MB per file
   │  count_pages: walk the PDF /Pages tree — NOT its self-declared /Count —
   │               inside a 2s Timeout, because both the xref subsection length
-  │               and the tree are attacker-controlled
+  │               and the tree are attacker-controlled; every FlateDecode
+  │               inflate is capped (initializer), because a 4 KB stream can
+  │               decode to gigabytes long before any timeout fires
   │  session.with_lock { re-check 20 MB / 20 pages, attach, increment }
   ▼
 POST /:id/commit → hold sized from pages → ProcessScribeSessionJob

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -103,7 +103,7 @@ isolation, metering, status rollup, webhooks) is the shared path, which is the
 whole reason OCR was modelled as a transcript-producing stage rather than a
 parallel pipeline.
 
-```
+```text
 POST /:id/documents  (one call per file, in page order)
   │  content-type allowlist + 10 MB per file
   │  count_pages: walk the PDF /Pages tree — NOT its self-declared /Count —
@@ -119,7 +119,10 @@ Orchestrator#transcript_from_documents!
   ▼
 Scribe::OcrStage
   │  max_tokens sized from the page count (2000/page, floored and capped) —
-  │  the adapters' 4096 default is a structuring budget and truncates a report
+  │  the adapters' 4096 default is a structuring budget and truncates a report;
+  │  each adapter then clamps it to what ITS model accepts (capabilities.
+  │  max_output_tokens, else a per-provider default), because a budget above
+  │  the model's ceiling is a 400 before any work is done
   │  Llm::Caller.ocr → primary, then fallback on a TRANSIENT error
   ▼
 Transcript (the audit trail of what the model read) → StructuringStage per output
@@ -131,7 +134,10 @@ out of output budget fails instead of persisting half a lab report that reads
 as complete. It is raised *inside* the adapter deliberately: only an error
 raised during the attempt is visible to `Llm::Caller`, which is what turns a
 truncation into a fallback attempt rather than an immediate session failure.
-`OcrStage` repeats the check as a backstop for any future adapter that forgets.
+A `refusal` / `content_filter` stop is raised as `Llm::Refused` instead — a
+decision, not a fault, so it is reported as such and not retried on the
+fallback. `OcrStage` repeats the completeness check as a backstop for any
+future adapter that forgets.
 
 **Billed-but-unusable attempts are recorded.** A truncated or empty completion
 still consumed tokens the provider will invoice, so `Llm::Error` carries that

--- a/test/controllers/playground_controller_test.rb
+++ b/test/controllers/playground_controller_test.rb
@@ -63,6 +63,22 @@ class PlaygroundControllerTest < ActionDispatch::IntegrationTest
     assert_select "[data-field-key='chief_complaint']", text: /Chief complaint/
   end
 
+  test "show offers both source modes and hands the browser the upload limits" do
+    sign_in @user
+    get template_playground_path(@template)
+
+    assert_response :success
+    assert_select "[data-playground-target='modeAudio']", text: /Record audio/
+    assert_select "[data-playground-target='modeDocument']", text: /Upload a report/
+    assert_select "input[type=file][data-playground-target='fileInput']"
+    # Rendered from the model constants, so a limit change cannot leave the
+    # browser refusing (or accepting) something the server does not.
+    assert_select "[data-playground-max-file-bytes-value=?]",
+                  ScribeSession::MAX_DOCUMENT_FILE_BYTES.to_s
+    assert_select "[data-playground-max-total-bytes-value=?]",
+                  ScribeSession::MAX_DOCUMENT_BYTES.to_s
+  end
+
   test "show offers nothing to run when the template has no fields" do
     sign_in @user
     empty = create(:template, account: @account, name: "Empty")
@@ -101,6 +117,44 @@ class PlaygroundControllerTest < ActionDispatch::IntegrationTest
     assert_equal 2, session.scribe_outputs.count
     assert_equal [ "form", "form" ], session.scribe_outputs.map(&:output_type)
     assert_equal [ @page.id, second.id ].sort, session.scribe_outputs.map(&:page_id).sort
+  end
+
+  test "create_session builds a document session when the browser asks for one" do
+    sign_in @user
+
+    assert_difference "ScribeSession.count", 1 do
+      post template_playground_sessions_path(@template), params: { modality: "document" }, as: :json
+    end
+
+    assert_response :created
+    body = JSON.parse(response.body)
+    assert_equal "document", body["modality"]
+
+    session = ScribeSession.find(body["session_id"])
+    assert_equal "document", session.modality
+    # The outputs are identical to an audio run's: modality decides only how the
+    # transcript comes to exist, never what is produced from it.
+    assert_equal [ "form" ], session.scribe_outputs.map(&:output_type)
+    assert_equal [ @page.id ], session.scribe_outputs.map(&:page_id)
+  end
+
+  test "create_session defaults to audio for a missing or unknown modality" do
+    sign_in @user
+
+    post template_playground_sessions_path(@template), as: :json
+    assert_equal "audio", ScribeSession.find(JSON.parse(response.body)["session_id"]).modality
+
+    post template_playground_sessions_path(@template), params: { modality: "telepathy" }, as: :json
+    assert_response :created
+    assert_equal "audio", ScribeSession.find(JSON.parse(response.body)["session_id"]).modality
+  end
+
+  test "the scoped token a document run uses names the document scope" do
+    sign_in @user
+    post template_playground_sessions_path(@template), params: { modality: "document" }, as: :json
+
+    claims = Scribe::SessionToken.verify(JSON.parse(response.body)["token"])
+    assert_includes claims["scope"], "document"
   end
 
   test "create_session returns a scoped token that verifies for this session" do

--- a/test/initializers/pdf_reader_inflate_cap_test.rb
+++ b/test/initializers/pdf_reader_inflate_cap_test.rb
@@ -1,0 +1,35 @@
+require "test_helper"
+
+# config/initializers/pdf_reader_inflate_cap.rb: pdf-reader's FlateDecode
+# filter must not be able to inflate a stream past a fixed ceiling, because a
+# few-KB PDF can decode to gigabytes and OOM the process before any wall-clock
+# timeout fires.
+class PdfReaderInflateCapTest < ActiveSupport::TestCase
+  def flate
+    PDF::Reader::Filter::Flate.new
+  end
+
+  test "an ordinary zlib stream still inflates exactly as before" do
+    original = "BT /F1 12 Tf 72 712 Td (Hemoglobin 13.5 g/dL) Tj ET\n" * 200
+    assert_equal original, flate.filter(Zlib::Deflate.deflate(original))
+  end
+
+  test "a raw deflate stream (no zlib header) still inflates via the second attempt" do
+    original = "raw " * 1000
+    raw = Zlib::Deflate.new(Zlib::DEFAULT_COMPRESSION, -Zlib::MAX_WBITS).deflate(original, Zlib::FINISH)
+    assert_equal original, flate.filter(raw)
+  end
+
+  test "a stream that inflates past the cap raises MalformedPDFError instead of allocating" do
+    bomb = Zlib::Deflate.deflate("\0" * (PdfReaderInflateCap::MAX_INFLATED_BYTES + 1.megabyte))
+    assert_operator bomb.bytesize, :<, 100.kilobytes, "the fixture is meant to be tiny on disk"
+
+    error = assert_raises(PDF::Reader::MalformedPDFError) { flate.filter(bomb) }
+    assert_match(/inflates past/, error.message)
+  end
+
+  test "garbage is still reported by the filter's own error, not the cap" do
+    error = assert_raises(PDF::Reader::MalformedPDFError) { flate.filter("this is not deflate data") }
+    assert_match(/no suitable inflation algorithm/, error.message)
+  end
+end

--- a/test/integration/api/v2/documents_test.rb
+++ b/test/integration/api/v2/documents_test.rb
@@ -1,4 +1,5 @@
 require "test_helper"
+require "mocha/minitest"
 
 module Api
   module V2
@@ -109,6 +110,116 @@ module Api
         assert_response :unprocessable_entity
       end
 
+      # ── the type is what the bytes say ───────────────────────────────────
+
+      # The multipart Content-Type is a client claim. Active Storage stores the
+      # sniffed type and the provider receives it, so counting pages by the
+      # DECLARED type let a 3-page PDF calling itself image/jpeg through as one
+      # page — under the cap, the hold and per-page metering — and then be OCR'd
+      # as the whole PDF.
+      test "a PDF declared as an image is counted and stored as a PDF" do
+        session_id = create_document_session
+        file = Tempfile.new([ "scan", ".jpg" ])
+        file.binmode
+        file.write(minimal_pdf(pages: 3))
+        file.rewind
+
+        post "/api/v2/scribe_sessions/#{session_id}/documents",
+             params: { document: Rack::Test::UploadedFile.new(file.path, "image/jpeg") },
+             headers: @headers
+
+        assert_response :ok
+        assert_equal 3, JSON.parse(response.body)["pages"], "counted by the declared type, not the bytes"
+        assert_equal "application/pdf", ScribeSession.find(session_id).document_files.first.blob.content_type
+      end
+
+      # The mirror image: allowed on the label, disallowed in the bytes. Before
+      # sniffing this passed the allowlist, then failed the model's content_type
+      # validation inside the row lock and 500'd.
+      test "a file whose bytes are not an allowed type is a 422 whatever it claims to be" do
+        session_id = create_document_session
+        file = Tempfile.new([ "scan", ".jpg" ])
+        file.binmode
+        file.write("GIF89a\x01\x00\x01\x00\x00\x00\x00;")
+        file.rewind
+
+        post "/api/v2/scribe_sessions/#{session_id}/documents",
+             params: { document: Rack::Test::UploadedFile.new(file.path, "image/jpeg") },
+             headers: @headers
+
+        assert_response :unprocessable_entity
+        body = JSON.parse(response.body)
+        assert_equal "validation_error", body.dig("error", "code")
+        assert_match(/image\/gif/, body.dig("error", "message"))
+        assert_equal 0, ScribeSession.find(session_id).document_files.count
+      end
+
+      # ── the lock's own guards ────────────────────────────────────────────
+
+      test "uploading to a session that has already been committed is a 409" do
+        session_id = create_document_session
+        post "/api/v2/scribe_sessions/#{session_id}/documents",
+             params: { document: pdf_upload(pages: 1) }, headers: @headers
+        assert_response :ok
+        ScribeSession.find(session_id).update!(status: "processing")
+
+        post "/api/v2/scribe_sessions/#{session_id}/documents",
+             params: { document: pdf_upload(pages: 1) }, headers: @headers
+
+        assert_response :conflict
+        body = JSON.parse(response.body)
+        assert_equal "validation_error", body.dig("error", "code")
+        assert_match(/from status processing/, body.dig("error", "message"))
+        assert_equal 1, ScribeSession.find(session_id).document_pages
+      end
+
+      test "the byte cap is enforced across separate uploads" do
+        session_id = create_document_session
+        # A stored blob whose recorded size sits just under the session ceiling,
+        # without pushing 20 MB through the request: the cap is a sum over blob
+        # byte_size, which is exactly what this exercises.
+        big = ActiveStorage::Blob.create_and_upload!(
+          io: StringIO.new(minimal_pdf(pages: 1)), filename: "big.pdf", content_type: "application/pdf"
+        )
+        ScribeSession.find(session_id).document_files.attach(big)
+        big.update_column(:byte_size, ScribeSession::MAX_DOCUMENT_BYTES - 16)
+
+        post "/api/v2/scribe_sessions/#{session_id}/documents",
+             params: { document: pdf_upload(pages: 1) }, headers: @headers
+
+        assert_response :unprocessable_entity
+        body = JSON.parse(response.body)
+        assert_equal "document_upload_failed", body.dig("error", "code")
+        assert_match(/total documents exceed/, body.dig("error", "message"))
+        assert_equal 0, ScribeSession.find(session_id).document_pages, "a rejected upload must not increment"
+      end
+
+      # ── failure surface ──────────────────────────────────────────────────
+
+      # Extraction does more than call a provider, and an internal exception's
+      # message routinely carries SQL, bucket names or paths. The session must
+      # still fail cleanly (outputs failed, session failed, nothing left at
+      # pending) but the client reads a generic message; the real one is logged.
+      test "an internal failure during extraction fails the session with a generic client message" do
+        session_id = create_document_session
+        post "/api/v2/scribe_sessions/#{session_id}/documents",
+             params: { document: pdf_upload(pages: 2) }, headers: @headers
+
+        ActiveStorage::Blob.any_instance.stubs(:download).raises(
+          ActiveRecord::StatementInvalid, "PG::UndefinedColumn: ERROR: column scribe_sessions.secret does not exist"
+        )
+        post "/api/v2/scribe_sessions/#{session_id}/commit", headers: @headers
+
+        session = ScribeSession.find(session_id)
+        assert_equal "failed", session.status
+        assert_equal "transcript extraction failed", session.error["message"]
+        assert_equal [ "failure" ], session.scribe_outputs.map(&:status).uniq
+
+        get "/api/v2/scribe_sessions/#{session_id}", headers: @headers
+        assert_no_match(/PG::|UndefinedColumn|secret/, response.body)
+        assert_equal 0, UsageEvent.where(scribe_session_id: session_id).count
+      end
+
       test "modality cross-uploads 409 both ways" do
         doc_session = create_document_session
         post "/api/v2/scribe_sessions/#{doc_session}/audio",
@@ -174,17 +285,22 @@ module Api
       end
 
       test "the page cap is enforced across separate uploads, not just per file" do
+        # Derived from the cap so this keeps testing the boundary if it moves:
+        # each file is under the cap on its own, and together they are over it.
+        first = ScribeSession::MAX_DOCUMENT_PAGES - 5
+        second = 6
+
         session_id = create_document_session
         post "/api/v2/scribe_sessions/#{session_id}/documents",
-             params: { document: pdf_upload(pages: 15) }, headers: @headers
+             params: { document: pdf_upload(pages: first) }, headers: @headers
         assert_response :ok
-        assert_equal 15, JSON.parse(response.body)["pages"]
+        assert_equal first, JSON.parse(response.body)["pages"]
 
         post "/api/v2/scribe_sessions/#{session_id}/documents",
-             params: { document: pdf_upload(pages: 10) }, headers: @headers
+             params: { document: pdf_upload(pages: second) }, headers: @headers
         assert_response :unprocessable_entity
         assert_equal "document_upload_failed", JSON.parse(response.body).dig("error", "code")
-        assert_equal 15, ScribeSession.find(session_id).document_pages, "a rejected upload must not increment"
+        assert_equal first, ScribeSession.find(session_id).document_pages, "a rejected upload must not increment"
       end
 
       # ── completeness + billing ───────────────────────────────────────────
@@ -271,6 +387,74 @@ module Api
         assert_equal 2, events.count, "the abandoned primary attempt was billed to nobody"
         assert_equal %w[failed finalized], events.map(&:status)
         assert_equal 4096, events.first.output_tokens
+      end
+
+      # The primary was billed (truncated 200) and the fallback then failed
+      # outright. The session fails, but the primary's spend must still reach the
+      # ledger: Llm::Caller used to let the fallback's exception escape with the
+      # primary error dropped on the floor.
+      test "a billed primary attempt is metered even when the fallback also fails" do
+        model = create(:ai_model, api_model_id: "gpt-4o-mini")
+        fallback = create(:ai_model, api_model_id: "claude-3-5-sonnet-latest",
+                                     ai_provider: create(:ai_provider, kind: "anthropic",
+                                                                       base_url: "https://api.anthropic.com"))
+        create(:model_assignment, scope_type: "System", scope_id: nil, function: "ocr",
+                                  ai_model: model, fallback_ai_model: fallback)
+
+        stub_request(:post, CHAT_URL).to_return(
+          status: 200, headers: { "Content-Type" => "application/json" },
+          body: { choices: [ { message: { content: "partial" }, finish_reason: "length" } ],
+                  usage: { prompt_tokens: 900, completion_tokens: 4096 } }.to_json
+        )
+        # Fallback: a transport failure — billed nothing, records nothing.
+        stub_request(:post, "https://api.anthropic.com/v1/messages").to_return(status: 502, body: "bad gateway")
+
+        session_id = create_document_session
+        post "/api/v2/scribe_sessions/#{session_id}/documents",
+             params: { document: pdf_upload(pages: 2) }, headers: @headers
+        post "/api/v2/scribe_sessions/#{session_id}/commit", headers: @headers
+
+        assert_equal "failed", ScribeSession.find(session_id).status
+        events = UsageEvent.where(scribe_session_id: session_id, function: "ocr").order(:id)
+        assert_equal 1, events.count, "the billed primary attempt was dropped when the fallback failed"
+        assert_equal "failed", events.first.status
+        assert_equal 4096, events.first.output_tokens
+        assert_equal 2, events.first.pages
+      end
+
+      # Both providers billed us and neither produced a usable report: two
+      # physical attempts, two failed rows, in the order they happened.
+      test "two billed-but-unusable attempts are both metered, in order" do
+        model = create(:ai_model, api_model_id: "gpt-4o-mini")
+        fallback = create(:ai_model, api_model_id: "claude-3-5-sonnet-latest",
+                                     ai_provider: create(:ai_provider, kind: "anthropic",
+                                                                       base_url: "https://api.anthropic.com"))
+        create(:model_assignment, scope_type: "System", scope_id: nil, function: "ocr",
+                                  ai_model: model, fallback_ai_model: fallback)
+
+        stub_request(:post, CHAT_URL).to_return(
+          status: 200, headers: { "Content-Type" => "application/json" },
+          body: { choices: [ { message: { content: "partial" }, finish_reason: "length" } ],
+                  usage: { prompt_tokens: 900, completion_tokens: 4096 } }.to_json
+        )
+        stub_request(:post, "https://api.anthropic.com/v1/messages").to_return(
+          status: 200, headers: { "Content-Type" => "application/json" },
+          body: { id: "m", type: "message", role: "assistant", stop_reason: "max_tokens",
+                  content: [ { type: "text", text: "also partial" } ],
+                  usage: { input_tokens: 800, output_tokens: 3000 } }.to_json
+        )
+
+        session_id = create_document_session
+        post "/api/v2/scribe_sessions/#{session_id}/documents",
+             params: { document: pdf_upload(pages: 2) }, headers: @headers
+        post "/api/v2/scribe_sessions/#{session_id}/commit", headers: @headers
+
+        assert_equal "failed", ScribeSession.find(session_id).status
+        events = UsageEvent.where(scribe_session_id: session_id, function: "ocr").order(:id)
+        assert_equal 2, events.count
+        assert_equal %w[failed failed], events.map(&:status)
+        assert_equal [ 4096, 3000 ], events.map(&:output_tokens), "primary first, then fallback"
+        assert_equal [ "#{session_id}:ocr:0", "#{session_id}:ocr:1" ], events.map(&:dedupe_key)
       end
 
       # A transport failure returned no tokens, so there is nothing to record —
@@ -383,13 +567,26 @@ module Api
         Rack::Test::UploadedFile.new(file.path, "application/pdf")
       end
 
-      # 238 bytes: the /Pages node lists itself as its own kid, so a page-tree
-      # walk with no cycle guard recurses until the stack overflows.
+      # Tiny: the /Pages node lists itself as its own kid, so a page-tree walk
+      # with no cycle guard recurses until the stack overflows.
+      #
+      # The xref offsets are computed from the object strings, never hand-counted:
+      # an offset that lands even one byte inside "2 0 obj" makes pdf-reader
+      # raise MalformedPDFError (a StandardError) BEFORE it ever walks the tree,
+      # and this test then passes for the wrong reason — the SystemStackError
+      # rescue it exists to guard would go unexercised.
       def cyclic_pdf_upload
         header = "%PDF-1.4\n"
-        body = "1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n" \
-               "2 0 obj\n<< /Type /Pages /Kids [2 0 R] /Count 1 >>\nendobj\n"
-        offsets = [ header.bytesize, header.bytesize + 50 ]
+        objects = [
+          "1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n",
+          "2 0 obj\n<< /Type /Pages /Kids [2 0 R] /Count 1 >>\nendobj\n"
+        ]
+        body = +""
+        offsets = []
+        objects.each do |obj|
+          offsets << (header.bytesize + body.bytesize)
+          body << obj
+        end
         xref_pos = header.bytesize + body.bytesize
         xref = +"xref\n0 3\n0000000000 65535 f \n"
         offsets.each { |o| xref << format("%010d 00000 n \n", o) }

--- a/test/integration/api/v2/documents_test.rb
+++ b/test/integration/api/v2/documents_test.rb
@@ -130,6 +130,197 @@ module Api
         assert_equal "document_upload_failed", JSON.parse(response.body).dig("error", "code")
       end
 
+      # ── upload hardening ─────────────────────────────────────────────────
+
+      # /Count is written by whoever made the file. Trusting it let a 40-page
+      # report declare itself as 1, slipping under MAX_DOCUMENT_PAGES and under
+      # the per-page credit hold while still costing 40 pages of vision tokens.
+      test "a PDF understating its own page count is counted by walking the page tree" do
+        session_id = create_document_session
+        post "/api/v2/scribe_sessions/#{session_id}/documents",
+             params: { document: pdf_upload(pages: 3, declared: 1) }, headers: @headers
+        assert_response :ok
+        assert_equal 3, JSON.parse(response.body)["pages"]
+      end
+
+      # A 300-byte file declaring a four-billion-entry xref subsection used to
+      # spin a Puma thread for hours; three of them took the whole pool down.
+      # The assertion that matters is that the request RETURNS, quickly.
+      test "a PDF declaring an enormous xref table cannot hang the request" do
+        session_id = create_document_session
+        started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        post "/api/v2/scribe_sessions/#{session_id}/documents",
+             params: { document: xref_bomb_upload }, headers: @headers
+        elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+
+        assert_response :unprocessable_entity
+        assert_operator elapsed, :<,
+                        Api::V2::ScribeSessionsController::PDF_PARSE_TIMEOUT_SECONDS + 5,
+                        "hostile PDF parsing was not bounded"
+      end
+
+      # pdf-reader walks /Kids with no cycle guard, so a page tree that lists
+      # itself as its own kid recurses until the stack blows. SystemStackError is
+      # NOT a StandardError, so a bare `rescue StandardError` misses it and the
+      # walk 500s on a public endpoint — a regression the page-tree fix
+      # introduced, since the old declared-/Count read returned a clean 200.
+      test "a PDF whose page tree contains a cycle is a 422, not a 500" do
+        session_id = create_document_session
+        post "/api/v2/scribe_sessions/#{session_id}/documents",
+             params: { document: cyclic_pdf_upload }, headers: @headers
+
+        assert_response :unprocessable_entity
+        assert_equal "validation_error", JSON.parse(response.body).dig("error", "code")
+      end
+
+      test "the page cap is enforced across separate uploads, not just per file" do
+        session_id = create_document_session
+        post "/api/v2/scribe_sessions/#{session_id}/documents",
+             params: { document: pdf_upload(pages: 15) }, headers: @headers
+        assert_response :ok
+        assert_equal 15, JSON.parse(response.body)["pages"]
+
+        post "/api/v2/scribe_sessions/#{session_id}/documents",
+             params: { document: pdf_upload(pages: 10) }, headers: @headers
+        assert_response :unprocessable_entity
+        assert_equal "document_upload_failed", JSON.parse(response.body).dig("error", "code")
+        assert_equal 15, ScribeSession.find(session_id).document_pages, "a rejected upload must not increment"
+      end
+
+      # ── completeness + billing ───────────────────────────────────────────
+
+      # The failure that used to be invisible: a 200 whose finish_reason says the
+      # model ran out of budget mid-report. The extracted half must NOT become
+      # the transcript, and the session must not read as completed.
+      test "a truncated extraction fails the session instead of persisting half a report" do
+        stub_request(:post, CHAT_URL).to_return(
+          status: 200, headers: { "Content-Type" => "application/json" },
+          body: { choices: [ { message: { content: "Hemoglobin | 13.5" }, finish_reason: "length" } ],
+                  usage: { prompt_tokens: 900, completion_tokens: 4096 } }.to_json
+        )
+
+        session_id = create_document_session
+        post "/api/v2/scribe_sessions/#{session_id}/documents",
+             params: { document: pdf_upload(pages: 12) }, headers: @headers
+        post "/api/v2/scribe_sessions/#{session_id}/commit", headers: @headers
+
+        session = ScribeSession.find(session_id)
+        assert_equal "failed", session.status
+        assert_nil session.transcript
+      end
+
+      # The provider counted those tokens whether or not we could use them, so
+      # the attempt is recorded — as :failed, and without deducting credits,
+      # because the customer is not charged for a run that produced nothing.
+      test "a billed-but-unusable OCR attempt is recorded as a failed usage event" do
+        stub_request(:post, CHAT_URL).to_return(
+          status: 200, headers: { "Content-Type" => "application/json" },
+          body: { choices: [ { message: { content: "partial" }, finish_reason: "length" } ],
+                  usage: { prompt_tokens: 900, completion_tokens: 4096 } }.to_json
+        )
+
+        session_id = create_document_session
+        post "/api/v2/scribe_sessions/#{session_id}/documents",
+             params: { document: pdf_upload(pages: 12) }, headers: @headers
+        post "/api/v2/scribe_sessions/#{session_id}/commit", headers: @headers
+
+        event = UsageEvent.find_by(scribe_session_id: session_id, function: "ocr")
+        assert event, "the billed attempt was absorbed silently"
+        assert_equal "failed", event.status
+        assert_equal 900, event.input_tokens
+        assert_equal 4096, event.output_tokens
+        # The adapter's usage carries no page count — only the success path
+        # grafts one on — so without help this prices the per-page component at
+        # zero and hides the quantity the commit hold was sized on.
+        assert_equal 12, event.pages
+      end
+
+      # A truncated primary that falls back is TWO physical attempts, and the
+      # provider billed both. Llm::Caller used to drop the primary's error on
+      # the floor, so its tokens were recorded nowhere at all.
+      test "an attempt abandoned for the fallback provider is still metered" do
+        model = create(:ai_model, api_model_id: "gpt-4o-mini")
+        fallback = create(:ai_model, api_model_id: "claude-3-5-sonnet-latest",
+                                     ai_provider: create(:ai_provider, kind: "anthropic",
+                                                                       base_url: "https://api.anthropic.com"))
+        create(:model_assignment, scope_type: "System", scope_id: nil, function: "ocr",
+                                  ai_model: model, fallback_ai_model: fallback)
+
+        # Primary: billed, truncated, unusable. Fallback: the full extraction.
+        stub_request(:post, CHAT_URL).to_return(
+          status: 200, headers: { "Content-Type" => "application/json" },
+          body: { choices: [ { message: { content: "partial" }, finish_reason: "length" } ],
+                  usage: { prompt_tokens: 900, completion_tokens: 4096 } }.to_json
+        )
+        stub_request(:post, "https://api.anthropic.com/v1/messages").to_return(
+          status: 200, headers: { "Content-Type" => "application/json" },
+          body: { id: "m", type: "message", role: "assistant", stop_reason: "end_turn",
+                  content: [ { type: "text", text: "Hemoglobin | 13.5 g/dL" } ],
+                  usage: { input_tokens: 800, output_tokens: 250 } }.to_json
+        )
+
+        session_id = create_document_session
+        post "/api/v2/scribe_sessions/#{session_id}/documents",
+             params: { document: pdf_upload(pages: 2) }, headers: @headers
+        post "/api/v2/scribe_sessions/#{session_id}/commit", headers: @headers
+
+        session = ScribeSession.find(session_id)
+        assert_includes session.transcript.text, "Hemoglobin"
+
+        events = UsageEvent.where(scribe_session_id: session_id, function: "ocr").order(:id)
+        assert_equal 2, events.count, "the abandoned primary attempt was billed to nobody"
+        assert_equal %w[failed finalized], events.map(&:status)
+        assert_equal 4096, events.first.output_tokens
+      end
+
+      # A transport failure returned no tokens, so there is nothing to record —
+      # recording a zero-cost row would just be noise in the ledger.
+      test "a transport failure records no usage event" do
+        stub_request(:post, CHAT_URL).to_return(status: 500, body: "boom")
+
+        session_id = create_document_session
+        post "/api/v2/scribe_sessions/#{session_id}/documents",
+             params: { document: pdf_upload(pages: 2) }, headers: @headers
+        post "/api/v2/scribe_sessions/#{session_id}/commit", headers: @headers
+
+        assert_equal "failed", ScribeSession.find(session_id).status
+        assert_equal 0, UsageEvent.where(scribe_session_id: session_id, function: "ocr").count
+      end
+
+      # Re-commit after a failed extraction runs OCR again — a second provider
+      # call, a second charge — so it must not collide with the first attempt's
+      # dedupe key and vanish.
+      test "re-committing after a failed extraction meters the second attempt separately" do
+        stub_request(:post, CHAT_URL).to_return(
+          # Attempt one: billed, truncated, unusable.
+          { status: 200, headers: { "Content-Type" => "application/json" },
+            body: { choices: [ { message: { content: "partial" }, finish_reason: "length" } ],
+                    usage: { prompt_tokens: 900, completion_tokens: 4096 } }.to_json },
+          # Attempt two: the full extraction, then structuring.
+          { status: 200, headers: { "Content-Type" => "application/json" },
+            body: { choices: [ { message: { content: "Hemoglobin | 13.5 g/dL" }, finish_reason: "stop" } ],
+                    usage: { prompt_tokens: 900, completion_tokens: 300 } }.to_json },
+          { status: 200, headers: { "Content-Type" => "application/json" },
+            body: { choices: [ { message: { content: {}.to_json }, finish_reason: "stop" } ],
+                    usage: { prompt_tokens: 100, completion_tokens: 10 } }.to_json }
+        )
+
+        session_id = create_document_session
+        post "/api/v2/scribe_sessions/#{session_id}/documents",
+             params: { document: pdf_upload(pages: 2) }, headers: @headers
+        post "/api/v2/scribe_sessions/#{session_id}/commit", headers: @headers
+        assert_equal "failed", ScribeSession.find(session_id).status
+
+        post "/api/v2/scribe_sessions/#{session_id}/commit", headers: @headers
+        session = ScribeSession.find(session_id)
+        assert_equal "completed", session.status
+        assert_includes session.transcript.text, "Hemoglobin"
+
+        events = UsageEvent.where(scribe_session_id: session_id, function: "ocr").order(:id)
+        assert_equal 2, events.count, "the retried OCR call was billed to nobody"
+        assert_equal %w[failed finalized], events.map(&:status)
+      end
+
       private
 
       def create_document_session
@@ -140,12 +331,14 @@ module Api
       end
 
       # A structurally valid multi-page PDF built with correct xref offsets so
-      # pdf-reader parses it.
-      def minimal_pdf(pages: 1)
+      # pdf-reader parses it. `declared` overrides the /Count entry independently
+      # of how many page objects actually exist, which is how a hostile file
+      # understates its size.
+      def minimal_pdf(pages: 1, declared: nil)
         kids = (0...pages).map { |i| "#{3 + i} 0 R" }.join(" ")
         objects = []
         objects << "1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n"
-        objects << "2 0 obj\n<< /Type /Pages /Kids [#{kids}] /Count #{pages} >>\nendobj\n"
+        objects << "2 0 obj\n<< /Type /Pages /Kids [#{kids}] /Count #{declared || pages} >>\nendobj\n"
         pages.times do |i|
           objects << "#{3 + i} 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>\nendobj\n"
         end
@@ -164,10 +357,47 @@ module Api
         header + body + xref + trailer
       end
 
-      def pdf_upload(pages: 1)
+      def pdf_upload(pages: 1, declared: nil)
         file = Tempfile.new([ "report", ".pdf" ])
         file.binmode
-        file.write(minimal_pdf(pages: pages))
+        file.write(minimal_pdf(pages: pages, declared: declared))
+        file.rewind
+        Rack::Test::UploadedFile.new(file.path, "application/pdf")
+      end
+
+      # Tiny, structurally plausible, and claims an xref subsection with four
+      # billion entries. pdf-reader loops that count verbatim.
+      def xref_bomb_upload
+        header = "%PDF-1.4\n"
+        body = "1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n" \
+               "2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n" \
+               "3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>\nendobj\n"
+        xref_pos = header.bytesize + body.bytesize
+        xref = "xref\n0 4000000000\n0000000000 65535 f \n"
+        trailer = "trailer\n<< /Size 4000000000 /Root 1 0 R >>\nstartxref\n#{xref_pos}\n%%EOF\n"
+
+        file = Tempfile.new([ "bomb", ".pdf" ])
+        file.binmode
+        file.write(header + body + xref + trailer)
+        file.rewind
+        Rack::Test::UploadedFile.new(file.path, "application/pdf")
+      end
+
+      # 238 bytes: the /Pages node lists itself as its own kid, so a page-tree
+      # walk with no cycle guard recurses until the stack overflows.
+      def cyclic_pdf_upload
+        header = "%PDF-1.4\n"
+        body = "1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n" \
+               "2 0 obj\n<< /Type /Pages /Kids [2 0 R] /Count 1 >>\nendobj\n"
+        offsets = [ header.bytesize, header.bytesize + 50 ]
+        xref_pos = header.bytesize + body.bytesize
+        xref = +"xref\n0 3\n0000000000 65535 f \n"
+        offsets.each { |o| xref << format("%010d 00000 n \n", o) }
+        trailer = "trailer\n<< /Size 3 /Root 1 0 R >>\nstartxref\n#{xref_pos}\n%%EOF\n"
+
+        file = Tempfile.new([ "cyclic", ".pdf" ])
+        file.binmode
+        file.write(header + body + xref + trailer)
         file.rewind
         Rack::Test::UploadedFile.new(file.path, "application/pdf")
       end

--- a/test/integration/api/v2/documents_test.rb
+++ b/test/integration/api/v2/documents_test.rb
@@ -284,6 +284,24 @@ module Api
         assert_equal "validation_error", JSON.parse(response.body).dig("error", "code")
       end
 
+      # The wall-clock bound does not bound allocation: PDF::Reader.new inflates
+      # a compressed xref stream in its constructor with no output cap, and a
+      # 4 KB nested-FlateDecode stream decodes to gigabytes in well under the
+      # 2 s timeout — the process was OOM-killed before the timer fired. The
+      # inflate is capped (config/initializers/pdf_reader_inflate_cap.rb), so
+      # this must be a quick 422 that never allocated more than the cap.
+      test "a PDF whose xref stream is a decompression bomb is a 422 without inflating it" do
+        session_id = create_document_session
+        started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        post "/api/v2/scribe_sessions/#{session_id}/documents",
+             params: { document: flate_bomb_pdf_upload }, headers: @headers
+        elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+
+        assert_response :unprocessable_entity
+        assert_equal "validation_error", JSON.parse(response.body).dig("error", "code")
+        assert_operator elapsed, :<, 5, "the bomb was inflated rather than refused"
+      end
+
       test "the page cap is enforced across separate uploads, not just per file" do
         # Derived from the cap so this keeps testing the boundary if it moves:
         # each file is under the cap on its own, and together they are over it.
@@ -596,6 +614,34 @@ module Api
         file.binmode
         file.write(header + body + xref + trailer)
         file.rewind
+        Rack::Test::UploadedFile.new(file.path, "application/pdf")
+      end
+
+      # A PDF 1.5 file whose cross-reference table is a compressed `/Type /XRef`
+      # stream — which PDF::Reader.new decodes eagerly, before anything is
+      # asked of it — and whose stream data is a nested FlateDecode bomb: zeros
+      # deflated twice, so a few hundred bytes on disk decode to ~64 MB per
+      # layer. Everything else in the file is a valid one-page document.
+      def flate_bomb_pdf_upload
+        header = "%PDF-1.5\n"
+        objects = [
+          "1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n",
+          "2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n",
+          "3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>\nendobj\n"
+        ]
+        body = objects.join
+        payload = Zlib::Deflate.deflate(Zlib::Deflate.deflate("\0" * 64.megabytes))
+        xref_offset = header.bytesize + body.bytesize
+        xref_stream = "4 0 obj\n<< /Type /XRef /Size 5 /W [1 4 2] /Root 1 0 R " \
+                      "/Filter [/FlateDecode /FlateDecode] /Length #{payload.bytesize} >>\n" \
+                      "stream\n#{payload}\nendstream\nendobj\n"
+        trailer = "startxref\n#{xref_offset}\n%%EOF\n"
+
+        file = Tempfile.new([ "bomb", ".pdf" ])
+        file.binmode
+        file.write(header + body + xref_stream + trailer)
+        file.rewind
+        assert_operator file.size, :<, 100.kilobytes, "the bomb is meant to be tiny on disk"
         Rack::Test::UploadedFile.new(file.path, "application/pdf")
       end
 

--- a/test/integration/api/v2/documents_test.rb
+++ b/test/integration/api/v2/documents_test.rb
@@ -9,6 +9,8 @@ module Api
     # loop, and metering records one :ocr event (with pages) plus one
     # :structuring event per output.
     class DocumentsTest < ActionDispatch::IntegrationTest
+      include PdfFixtures
+
       CHAT_URL = "https://api.openai.com/v1/chat/completions".freeze
 
       setup do
@@ -530,33 +532,6 @@ module Api
              params: { modality: "document", outputs: [ { type: "transcript" } ] }.to_json,
              headers: @headers.merge("Content-Type" => "application/json")
         JSON.parse(response.body)["id"]
-      end
-
-      # A structurally valid multi-page PDF built with correct xref offsets so
-      # pdf-reader parses it. `declared` overrides the /Count entry independently
-      # of how many page objects actually exist, which is how a hostile file
-      # understates its size.
-      def minimal_pdf(pages: 1, declared: nil)
-        kids = (0...pages).map { |i| "#{3 + i} 0 R" }.join(" ")
-        objects = []
-        objects << "1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n"
-        objects << "2 0 obj\n<< /Type /Pages /Kids [#{kids}] /Count #{declared || pages} >>\nendobj\n"
-        pages.times do |i|
-          objects << "#{3 + i} 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>\nendobj\n"
-        end
-
-        header = "%PDF-1.4\n"
-        body = +""
-        offsets = []
-        objects.each do |obj|
-          offsets << (header.bytesize + body.bytesize)
-          body << obj
-        end
-        xref_pos = header.bytesize + body.bytesize
-        xref = +"xref\n0 #{objects.size + 1}\n0000000000 65535 f \n"
-        offsets.each { |offset| xref << format("%010d 00000 n \n", offset) }
-        trailer = "trailer\n<< /Size #{objects.size + 1} /Root 1 0 R >>\nstartxref\n#{xref_pos}\n%%EOF\n"
-        header + body + xref + trailer
       end
 
       def pdf_upload(pages: 1, declared: nil)

--- a/test/serializers/scribe_session_serializer_test.rb
+++ b/test/serializers/scribe_session_serializer_test.rb
@@ -17,4 +17,29 @@ class ScribeSessionSerializerTest < ActiveSupport::TestCase
     assert_equal "the patient has a fever", json[:transcript][:text]
     assert_equal "en", json[:transcript][:language]
   end
+
+  # A billed-but-unusable attempt is in the ledger as :failed but is not charged
+  # to the customer, so the session's usage — what the customer reads as their
+  # cost — must not include it. Otherwise a session that failed outright would
+  # report a cost, contradicting the API's "a run that produced nothing costs
+  # nothing".
+  test "usage sums finalized events only, never failed attempts" do
+    session = create(:scribe_session, modality: "document")
+    UsageEvent.create!(account: session.account, scribe_session: session, function: "ocr",
+                       status: "failed", cost: 0.02, total_tokens: 5000, pages: 3,
+                       input_tokens: 900, output_tokens: 4100)
+    UsageEvent.create!(account: session.account, scribe_session: session, function: "ocr",
+                       status: "finalized", cost: 0.01, total_tokens: 1200, pages: 3,
+                       input_tokens: 900, output_tokens: 300)
+    UsageEvent.create!(account: session.account, scribe_session: session, function: "structuring",
+                       status: "finalized", cost: 0.001, total_tokens: 400,
+                       input_tokens: 350, output_tokens: 50)
+
+    usage = ScribeSessionSerializer.new(session.reload).as_json[:usage]
+    assert_in_delta 0.011, usage[:cost], 1e-9
+    assert_equal 1600, usage[:total_tokens]
+    assert_equal 3, usage[:pages]
+    assert_in_delta 0.01, usage[:by_function]["ocr"], 1e-9
+    assert_in_delta 0.001, usage[:by_function]["structuring"], 1e-9
+  end
 end

--- a/test/services/scribe/ocr_stage_test.rb
+++ b/test/services/scribe/ocr_stage_test.rb
@@ -16,9 +16,12 @@ require "base64"
 require "active_support"
 require "active_support/core_ext/object/blank"
 
-unless defined?(Rails)
+# `defined?(Rails)` alone is not enough: `bin/rails test <this file>` defines the
+# constant without booting the app, so nothing autoloads and Scribe/Llm are
+# missing. Require the files ourselves unless the app is actually initialized.
+unless defined?(Rails) && Rails.respond_to?(:application) && Rails.application&.initialized?
   llm = File.expand_path("../../../app/services/llm", __dir__)
-  %w[usage result error timeout rate_limited bad_response config adapter
+  %w[usage result error timeout rate_limited bad_response refused config adapter
      adapters/anthropic adapters/openai_compatible registry caller].each { |f| require_relative "#{llm}/#{f}" }
   require_relative File.expand_path("../../../app/services/scribe/ocr_stage", __dir__)
 end
@@ -30,15 +33,16 @@ class OcrStageTest < Minitest::Test
   def setup; WebMock.disable_net_connect!; end
   def teardown; WebMock.reset!; end
 
-  def anthropic_config(fallback: nil)
+  def anthropic_config(fallback: nil, capabilities: {})
     Llm::Config.new(provider_kind: :anthropic, api_model_id: "claude-3-5-sonnet-latest",
                     base_url: "https://api.anthropic.com", api_key: "sk-ant-test",
-                    fallback: fallback)
+                    capabilities: capabilities, fallback: fallback)
   end
 
-  def openai_config
+  def openai_config(capabilities: {}, options: {})
     Llm::Config.new(provider_kind: :openai_compatible, api_model_id: "gpt-4o-mini",
-                    base_url: "https://api.openai.com/", api_key: "sk-test")
+                    base_url: "https://api.openai.com/", api_key: "sk-test",
+                    capabilities: capabilities, options: options)
   end
 
   def anthropic_body(text: "Hemoglobin | 13.5 g/dL", stop: "end_turn")
@@ -102,6 +106,30 @@ class OcrStageTest < Minitest::Test
     assert_requested :post, CHAT_URL, times: 1
   end
 
+  # A refusal is a decision, not a truncation: the client must not be told the
+  # document was too long, and the fallback provider is not spent on it (Refused
+  # is outside Caller::TRANSIENT). It is still a billed round-trip.
+  def test_a_refusal_raises_refused_and_is_not_retried_on_the_fallback
+    stub_request(:post, MESSAGES_URL).to_return(anthropic_body(text: "I can't help with that.", stop: "refusal"))
+    stub_request(:post, CHAT_URL).to_return(openai_body(text: "Full report text"))
+
+    error = assert_raises(Llm::Refused) do
+      Scribe::OcrStage.new(config: anthropic_config(fallback: openai_config)).call(documents, pages: 2)
+    end
+    assert_match(/refused/, error.message)
+    assert_equal false, error.message.include?("too long"), "a refusal must not be diagnosed as truncation"
+    assert error.billable?
+    assert_not_requested :post, CHAT_URL
+  end
+
+  def test_openai_content_filter_is_a_refusal_too
+    stub_request(:post, CHAT_URL).to_return(openai_body(finish: "content_filter"))
+
+    assert_raises(Llm::Refused) do
+      Scribe::OcrStage.new(config: openai_config).call(documents, pages: 2)
+    end
+  end
+
   def test_finish_reason_is_carried_on_the_result
     stub_request(:post, MESSAGES_URL).to_return(anthropic_body(stop: "end_turn"))
     result = Scribe::OcrStage.new(config: anthropic_config).call(documents, pages: 1)
@@ -112,10 +140,10 @@ class OcrStageTest < Minitest::Test
 
   def test_max_tokens_scales_with_page_count_not_the_structuring_default
     stub_request(:post, MESSAGES_URL).to_return(anthropic_body)
-    Scribe::OcrStage.new(config: anthropic_config).call(documents, pages: 12)
+    Scribe::OcrStage.new(config: anthropic_config).call(documents, pages: 3)
 
     assert_requested(:post, MESSAGES_URL) do |req|
-      JSON.parse(req.body)["max_tokens"] == 12 * Scribe::OcrStage::TOKENS_PER_PAGE
+      JSON.parse(req.body)["max_tokens"] == 3 * Scribe::OcrStage::TOKENS_PER_PAGE
     end
   end
 
@@ -128,22 +156,113 @@ class OcrStageTest < Minitest::Test
     end
   end
 
-  # A spoofed page count must not turn into an absurd completion request.
+  # A spoofed page count must not turn into an absurd completion request. The
+  # model here declares a huge ceiling so it is the STAGE cap being exercised,
+  # not the adapter's.
   def test_max_tokens_is_capped
     stub_request(:post, MESSAGES_URL).to_return(anthropic_body)
-    Scribe::OcrStage.new(config: anthropic_config).call(documents, pages: 100_000)
+    Scribe::OcrStage.new(config: anthropic_config(capabilities: { max_output_tokens: 1_000_000 }))
+                    .call(documents, pages: 100_000)
 
     assert_requested(:post, MESSAGES_URL) do |req|
       JSON.parse(req.body)["max_tokens"] == Scribe::OcrStage::MAX_MAX_TOKENS
     end
   end
 
-  def test_openai_ocr_sends_the_budget_too
+  # ── output ceiling ───────────────────────────────────────────────────────
+  #
+  # Providers 400 a request whose budget exceeds the model's output ceiling,
+  # before doing any work. A budget sized only from the page count would fail
+  # every long document outright on the default models (gpt-4o-mini: 16k,
+  # claude-3-5-*: 8k), so each adapter clamps to what ITS model accepts.
+
+  def test_anthropic_clamps_the_budget_to_its_default_output_ceiling
+    stub_request(:post, MESSAGES_URL).to_return(anthropic_body)
+    Scribe::OcrStage.new(config: anthropic_config).call(documents, pages: 12)
+
+    assert_requested(:post, MESSAGES_URL) do |req|
+      JSON.parse(req.body)["max_tokens"] == Llm::Adapters::Anthropic::DEFAULT_OUTPUT_CEILING
+    end
+  end
+
+  def test_openai_clamps_the_budget_to_its_default_output_ceiling
+    stub_request(:post, CHAT_URL).to_return(openai_body)
+    Scribe::OcrStage.new(config: openai_config).call(documents, pages: 12)
+
+    assert_requested(:post, CHAT_URL) do |req|
+      JSON.parse(req.body)["max_completion_tokens"] == Llm::Adapters::OpenaiCompatible::DEFAULT_OUTPUT_CEILING
+    end
+  end
+
+  # A model that allows more says so in capabilities, and the page-sized budget
+  # then goes through unclamped.
+  def test_a_declared_max_output_tokens_capability_raises_the_ceiling
+    stub_request(:post, MESSAGES_URL).to_return(anthropic_body)
+    Scribe::OcrStage.new(config: anthropic_config(capabilities: { max_output_tokens: 64_000 }))
+                    .call(documents, pages: 12)
+
+    assert_requested(:post, MESSAGES_URL) do |req|
+      JSON.parse(req.body)["max_tokens"] == 12 * Scribe::OcrStage::TOKENS_PER_PAGE
+    end
+  end
+
+  # The assignment's options can also carry it, for a model row nobody has
+  # annotated yet.
+  def test_an_assignment_option_can_declare_the_ceiling_too
+    stub_request(:post, CHAT_URL).to_return(openai_body)
+    Scribe::OcrStage.new(config: openai_config(options: { max_output_tokens: 32_768 }))
+                    .call(documents, pages: 12)
+
+    assert_requested(:post, CHAT_URL) do |req|
+      JSON.parse(req.body)["max_completion_tokens"] == 12 * Scribe::OcrStage::TOKENS_PER_PAGE
+    end
+  end
+
+  # Primary and fallback are different models with different ceilings; the
+  # SAME requested budget must be clamped for each, or the fallback 400s on a
+  # number that suited the primary.
+  def test_the_fallback_attempt_is_clamped_to_its_own_ceiling
+    stub_request(:post, CHAT_URL).to_return(openai_body(finish: "length"))
+    stub_request(:post, MESSAGES_URL).to_return(anthropic_body(text: "Full report text"))
+
+    openai_primary = Llm::Config.new(provider_kind: :openai_compatible, api_model_id: "gpt-4o-mini",
+                                     base_url: "https://api.openai.com/", api_key: "sk-test",
+                                     fallback: anthropic_config)
+    result = Scribe::OcrStage.new(config: openai_primary).call(documents, pages: 12)
+
+    assert_equal "Full report text", result.text
+    assert_requested(:post, CHAT_URL) do |req|
+      JSON.parse(req.body)["max_completion_tokens"] == 16_384
+    end
+    assert_requested(:post, MESSAGES_URL) do |req|
+      JSON.parse(req.body)["max_tokens"] == 8_192
+    end
+  end
+
+  # OpenAI proper: `max_tokens` is deprecated there and rejected by the o-series
+  # and GPT-5, while `max_completion_tokens` is accepted by every current model.
+  def test_openai_ocr_sends_the_budget_as_max_completion_tokens
     stub_request(:post, CHAT_URL).to_return(openai_body)
     Scribe::OcrStage.new(config: openai_config).call(documents, pages: 6)
 
     assert_requested(:post, CHAT_URL) do |req|
-      JSON.parse(req.body)["max_tokens"] == 6 * Scribe::OcrStage::TOKENS_PER_PAGE
+      body = JSON.parse(req.body)
+      body["max_completion_tokens"] == 6 * Scribe::OcrStage::TOKENS_PER_PAGE && !body.key?("max_tokens")
+    end
+  end
+
+  # Any other OpenAI-compatible endpoint (Ollama, vLLM, OpenRouter, ...) gets the
+  # universally understood `max_tokens`; some of them reject the newer name.
+  def test_other_openai_compatible_hosts_get_max_tokens
+    compat_url = "https://llm.internal.example/v1/chat/completions"
+    config = Llm::Config.new(provider_kind: :openai_compatible, api_model_id: "qwen2.5-vl",
+                             base_url: "https://llm.internal.example/", api_key: "k")
+    stub_request(:post, compat_url).to_return(openai_body)
+    Scribe::OcrStage.new(config: config).call(documents, pages: 6)
+
+    assert_requested(:post, compat_url) do |req|
+      body = JSON.parse(req.body)
+      body["max_tokens"] == 6 * Scribe::OcrStage::TOKENS_PER_PAGE && !body.key?("max_completion_tokens")
     end
   end
 

--- a/test/services/scribe/ocr_stage_test.rb
+++ b/test/services/scribe/ocr_stage_test.rb
@@ -206,15 +206,17 @@ class OcrStageTest < Minitest::Test
     end
   end
 
-  # The assignment's options can also carry it, for a model row nobody has
-  # annotated yet.
-  def test_an_assignment_option_can_declare_the_ceiling_too
+  # The ceiling is a MODEL property. ConfigResolver hands the primary
+  # assignment's options to the fallback Config too, so an options-declared
+  # ceiling would be applied to a different model on the fallback path; it is
+  # therefore ignored here on purpose.
+  def test_the_ceiling_is_never_read_from_the_assignment_options
     stub_request(:post, CHAT_URL).to_return(openai_body)
     Scribe::OcrStage.new(config: openai_config(options: { max_output_tokens: 32_768 }))
                     .call(documents, pages: 12)
 
     assert_requested(:post, CHAT_URL) do |req|
-      JSON.parse(req.body)["max_completion_tokens"] == 12 * Scribe::OcrStage::TOKENS_PER_PAGE
+      JSON.parse(req.body)["max_completion_tokens"] == Llm::Adapters::OpenaiCompatible::DEFAULT_OUTPUT_CEILING
     end
   end
 

--- a/test/services/scribe/ocr_stage_test.rb
+++ b/test/services/scribe/ocr_stage_test.rb
@@ -1,0 +1,216 @@
+# OcrStage tests against stubbed HTTP (WebMock). No DB.
+# Standalone: `ruby -Itest test/services/scribe/ocr_stage_test.rb`
+#
+# The stage is where OCR's completeness contract lives. An adapter may or may
+# not notice a truncated response; the stage must, for every provider, because a
+# half-transcribed lab report persisted as THE transcript is the failure mode
+# that reaches a clinician looking exactly like a success.
+require "minitest/autorun"
+require "webmock/minitest"
+require "openai"
+# Bundled, not default, since Ruby 3.4 — Rails requires it for us, a standalone
+# run does not, and the adapters base64 every document.
+require "base64"
+# Both adapters' #ocr reach for blank?/presence when deciding whether a 200
+# actually carried text, so the standalone run needs those core_ext too.
+require "active_support"
+require "active_support/core_ext/object/blank"
+
+unless defined?(Rails)
+  llm = File.expand_path("../../../app/services/llm", __dir__)
+  %w[usage result error timeout rate_limited bad_response config adapter
+     adapters/anthropic adapters/openai_compatible registry caller].each { |f| require_relative "#{llm}/#{f}" }
+  require_relative File.expand_path("../../../app/services/scribe/ocr_stage", __dir__)
+end
+
+class OcrStageTest < Minitest::Test
+  MESSAGES_URL = "https://api.anthropic.com/v1/messages".freeze
+  CHAT_URL = "https://api.openai.com/v1/chat/completions".freeze
+
+  def setup; WebMock.disable_net_connect!; end
+  def teardown; WebMock.reset!; end
+
+  def anthropic_config(fallback: nil)
+    Llm::Config.new(provider_kind: :anthropic, api_model_id: "claude-3-5-sonnet-latest",
+                    base_url: "https://api.anthropic.com", api_key: "sk-ant-test",
+                    fallback: fallback)
+  end
+
+  def openai_config
+    Llm::Config.new(provider_kind: :openai_compatible, api_model_id: "gpt-4o-mini",
+                    base_url: "https://api.openai.com/", api_key: "sk-test")
+  end
+
+  def anthropic_body(text: "Hemoglobin | 13.5 g/dL", stop: "end_turn")
+    { status: 200, headers: { "Content-Type" => "application/json" },
+      body: { id: "msg_1", type: "message", role: "assistant", stop_reason: stop,
+              content: [ { type: "text", text: text } ],
+              usage: { input_tokens: 900, output_tokens: 120 } }.to_json }
+  end
+
+  def openai_body(text: "Hemoglobin | 13.5 g/dL", finish: "stop")
+    { status: 200, headers: { "Content-Type" => "application/json" },
+      body: { choices: [ { message: { content: text }, finish_reason: finish } ],
+              usage: { prompt_tokens: 900, completion_tokens: 120 } }.to_json }
+  end
+
+  def documents
+    [ { data: "%PDF-1.4 bytes", content_type: "application/pdf", filename: "cbc.pdf" } ]
+  end
+
+  # ── completeness ─────────────────────────────────────────────────────────
+
+  def test_anthropic_truncation_raises_instead_of_persisting_a_partial_report
+    # The regression this guard exists for: Anthropic answers 200 with real text
+    # and stop_reason "max_tokens". The adapter is happy (the text is not blank),
+    # so before the stage guard this half-report became the clinical transcript.
+    stub_request(:post, MESSAGES_URL).to_return(anthropic_body(text: "Hemoglobin | 13.5", stop: "max_tokens"))
+
+    error = assert_raises(Llm::BadResponse) do
+      Scribe::OcrStage.new(config: anthropic_config).call(documents, pages: 12)
+    end
+    assert_match(/max_tokens/, error.message)
+  end
+
+  def test_openai_truncation_raises
+    stub_request(:post, CHAT_URL).to_return(openai_body(finish: "length"))
+
+    assert_raises(Llm::BadResponse) do
+      Scribe::OcrStage.new(config: openai_config).call(documents, pages: 12)
+    end
+  end
+
+  def test_end_turn_and_stop_both_count_as_complete
+    stub_request(:post, MESSAGES_URL).to_return(anthropic_body(stop: "end_turn"))
+    assert_equal "Hemoglobin | 13.5 g/dL",
+                 Scribe::OcrStage.new(config: anthropic_config).call(documents, pages: 2).text
+
+    stub_request(:post, CHAT_URL).to_return(openai_body(finish: "stop"))
+    assert_equal "Hemoglobin | 13.5 g/dL",
+                 Scribe::OcrStage.new(config: openai_config).call(documents, pages: 2).text
+  end
+
+  # BadResponse is one of Llm::Caller::TRANSIENT, so a truncated primary must
+  # spend the configured fallback rather than failing the session outright.
+  def test_truncation_falls_back_to_the_secondary_provider
+    stub_request(:post, MESSAGES_URL).to_return(anthropic_body(stop: "max_tokens"))
+    stub_request(:post, CHAT_URL).to_return(openai_body(text: "Full report text"))
+
+    result = Scribe::OcrStage.new(config: anthropic_config(fallback: openai_config))
+                             .call(documents, pages: 4)
+    assert_equal "Full report text", result.text
+    assert_requested :post, CHAT_URL, times: 1
+  end
+
+  def test_finish_reason_is_carried_on_the_result
+    stub_request(:post, MESSAGES_URL).to_return(anthropic_body(stop: "end_turn"))
+    result = Scribe::OcrStage.new(config: anthropic_config).call(documents, pages: 1)
+    assert_equal "end_turn", result.finish_reason
+  end
+
+  # ── output budget ────────────────────────────────────────────────────────
+
+  def test_max_tokens_scales_with_page_count_not_the_structuring_default
+    stub_request(:post, MESSAGES_URL).to_return(anthropic_body)
+    Scribe::OcrStage.new(config: anthropic_config).call(documents, pages: 12)
+
+    assert_requested(:post, MESSAGES_URL) do |req|
+      JSON.parse(req.body)["max_tokens"] == 12 * Scribe::OcrStage::TOKENS_PER_PAGE
+    end
+  end
+
+  def test_max_tokens_has_a_floor_for_single_page_and_image_uploads
+    stub_request(:post, MESSAGES_URL).to_return(anthropic_body)
+    Scribe::OcrStage.new(config: anthropic_config).call(documents, pages: 1)
+
+    assert_requested(:post, MESSAGES_URL) do |req|
+      JSON.parse(req.body)["max_tokens"] == Scribe::OcrStage::MIN_MAX_TOKENS
+    end
+  end
+
+  # A spoofed page count must not turn into an absurd completion request.
+  def test_max_tokens_is_capped
+    stub_request(:post, MESSAGES_URL).to_return(anthropic_body)
+    Scribe::OcrStage.new(config: anthropic_config).call(documents, pages: 100_000)
+
+    assert_requested(:post, MESSAGES_URL) do |req|
+      JSON.parse(req.body)["max_tokens"] == Scribe::OcrStage::MAX_MAX_TOKENS
+    end
+  end
+
+  def test_openai_ocr_sends_the_budget_too
+    stub_request(:post, CHAT_URL).to_return(openai_body)
+    Scribe::OcrStage.new(config: openai_config).call(documents, pages: 6)
+
+    assert_requested(:post, CHAT_URL) do |req|
+      JSON.parse(req.body)["max_tokens"] == 6 * Scribe::OcrStage::TOKENS_PER_PAGE
+    end
+  end
+
+  # ── page count on usage ──────────────────────────────────────────────────
+
+  def test_pages_are_grafted_onto_provider_usage_without_clobbering_tokens
+    stub_request(:post, MESSAGES_URL).to_return(anthropic_body)
+    result = Scribe::OcrStage.new(config: anthropic_config).call(documents, pages: 3)
+
+    assert_equal 3, result.pages
+    assert_equal 3, result.usage.pages
+    assert_equal 900, result.usage.input_tokens
+    assert_equal 120, result.usage.output_tokens
+  end
+
+  # No usage block from the provider still has to bill per page, so the count
+  # survives and the event is flagged estimated.
+  def test_pages_survive_a_missing_usage_block
+    stub_request(:post, MESSAGES_URL).to_return(
+      status: 200, headers: { "Content-Type" => "application/json" },
+      body: { id: "m", type: "message", role: "assistant", stop_reason: "end_turn",
+              content: [ { type: "text", text: "text" } ] }.to_json
+    )
+    result = Scribe::OcrStage.new(config: anthropic_config).call(documents, pages: 5)
+
+    assert_equal 5, result.usage.pages
+    assert result.usage.estimated
+  end
+
+  # ── request shape ────────────────────────────────────────────────────────
+
+  def test_a_pdf_is_sent_as_a_base64_document_block
+    stub_request(:post, MESSAGES_URL).to_return(anthropic_body)
+    Scribe::OcrStage.new(config: anthropic_config).call(documents, pages: 1)
+
+    assert_requested(:post, MESSAGES_URL) do |req|
+      block = JSON.parse(req.body).dig("messages", 0, "content", 0)
+      block["type"] == "document" &&
+        block.dig("source", "media_type") == "application/pdf" &&
+        block.dig("source", "data") == Base64.strict_encode64("%PDF-1.4 bytes")
+    end
+  end
+
+  def test_an_image_is_sent_as_an_image_block
+    stub_request(:post, MESSAGES_URL).to_return(anthropic_body)
+    Scribe::OcrStage.new(config: anthropic_config).call(
+      [ { data: "PNGDATA", content_type: "image/png", filename: "scan.png" } ], pages: 1
+    )
+
+    assert_requested(:post, MESSAGES_URL) do |req|
+      JSON.parse(req.body).dig("messages", 0, "content", 0, "type") == "image"
+    end
+  end
+
+  # Every uploaded file reaches the provider in one request, in the order given
+  # — the orchestrator sorts by attachment id so that order is page order.
+  def test_every_document_is_sent_in_order_in_one_request
+    stub_request(:post, MESSAGES_URL).to_return(anthropic_body)
+    Scribe::OcrStage.new(config: anthropic_config).call(
+      [ { data: "one", content_type: "image/png", filename: "1.png" },
+       { data: "two", content_type: "image/png", filename: "2.png" },
+       { data: "three", content_type: "image/png", filename: "3.png" } ], pages: 3
+    )
+
+    assert_requested(:post, MESSAGES_URL, times: 1) do |req|
+      blocks = JSON.parse(req.body).dig("messages", 0, "content")
+      blocks.first(3).map { |b| Base64.decode64(b.dig("source", "data")) } == %w[one two three]
+    end
+  end
+end

--- a/test/services/scribe/session_token_test.rb
+++ b/test/services/scribe/session_token_test.rb
@@ -9,7 +9,8 @@ class Scribe::SessionTokenTest < ActiveSupport::TestCase
     assert exp <= @session.expires_at
     claims = Scribe::SessionToken.verify(token)
     assert_equal @session.id, claims["sid"]
-    assert_equal %w[audio read], claims["scope"]
+    assert_equal Scribe::SessionToken::SCOPE, claims["scope"]
+    assert_includes claims["scope"], "document"
   end
 
   test "verify rejects tampered, foreign-prefix, and expired tokens" do

--- a/test/support/pdf_fixtures.rb
+++ b/test/support/pdf_fixtures.rb
@@ -1,0 +1,29 @@
+# Structurally valid PDFs built with correct xref offsets, so pdf-reader parses
+# them. Shared by the API integration suite (uploads through Rack::Test) and
+# the browser system suite (files on disk for a real file dialog).
+module PdfFixtures
+  # `declared` overrides the /Count entry independently of how many page
+  # objects actually exist, which is how a hostile file understates its size.
+  def minimal_pdf(pages: 1, declared: nil)
+    kids = (0...pages).map { |i| "#{3 + i} 0 R" }.join(" ")
+    objects = []
+    objects << "1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n"
+    objects << "2 0 obj\n<< /Type /Pages /Kids [#{kids}] /Count #{declared || pages} >>\nendobj\n"
+    pages.times do |i|
+      objects << "#{3 + i} 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>\nendobj\n"
+    end
+
+    header = "%PDF-1.4\n"
+    body = +""
+    offsets = []
+    objects.each do |obj|
+      offsets << (header.bytesize + body.bytesize)
+      body << obj
+    end
+    xref_pos = header.bytesize + body.bytesize
+    xref = +"xref\n0 #{objects.size + 1}\n0000000000 65535 f \n"
+    offsets.each { |offset| xref << format("%010d 00000 n \n", offset) }
+    trailer = "trailer\n<< /Size #{objects.size + 1} /Root 1 0 R >>\nstartxref\n#{xref_pos}\n%%EOF\n"
+    header + body + xref + trailer
+  end
+end

--- a/test/system/playground_test.rb
+++ b/test/system/playground_test.rb
@@ -147,4 +147,76 @@ class PlaygroundTest < ApplicationSystemTestCase
     # button itself is the way back.
     assert_no_selector "[data-playground-target='retry']:not(.hidden)"
   end
+
+  # ── document (OCR) mode ───────────────────────────────────────────────────
+  #
+  # These stop at "the file is chosen and extraction is armed", for the same
+  # reason the recording tests stop at "recording has started": everything past
+  # the upload is a provider round-trip that the integration suite already
+  # covers without a browser. What cannot be covered without one is the mode
+  # switch itself and the client-side file guard.
+
+  test "switching to document mode swaps the recorder for an upload control" do
+    visit template_playground_path(@template)
+    assert_selector "button[aria-label='Start recording']"
+
+    click_on "Upload a report"
+
+    assert_selector "button[aria-label='Choose a document']"
+    assert_no_selector "button[aria-label='Start recording']"
+    assert_text "Choose a lab report"
+    assert_button "Extract", disabled: true
+  end
+
+  test "choosing a report lists it and arms extraction" do
+    visit template_playground_path(@template)
+    click_on "Upload a report"
+
+    attach_file(nil, pdf_fixture, make_visible: true)
+
+    assert_text "report.pdf"
+    assert_button "Extract", disabled: false
+    assert_text(/1 file ready/i)
+  end
+
+  test "an unsupported file is refused in the browser, before any upload" do
+    visit template_playground_path(@template)
+    click_on "Upload a report"
+
+    assert_no_difference -> { ScribeSession.count } do
+      attach_file(nil, text_fixture, make_visible: true)
+      assert_text "is not a PDF or an image"
+    end
+    assert_button "Extract", disabled: true
+  end
+
+  test "switching back to audio restores the recorder and forgets the file" do
+    visit template_playground_path(@template)
+    click_on "Upload a report"
+    attach_file(nil, pdf_fixture, make_visible: true)
+    assert_text "report.pdf"
+
+    click_on "Record audio"
+
+    assert_selector "button[aria-label='Start recording']"
+    assert_no_text "report.pdf"
+    assert_text "Press record and describe a consultation out loud"
+  end
+
+  private
+
+  # Written once per example into the test's tmp dir; content is irrelevant
+  # because nothing here uploads it — only the browser-side type and size
+  # checks read the File object.
+  def pdf_fixture
+    path = Rails.root.join("tmp", "report.pdf")
+    File.binwrite(path, "%PDF-1.4\n%%EOF\n")
+    path.to_s
+  end
+
+  def text_fixture
+    path = Rails.root.join("tmp", "notes.txt")
+    File.write(path, "not a lab report")
+    path.to_s
+  end
 end

--- a/test/system/playground_test.rb
+++ b/test/system/playground_test.rb
@@ -9,6 +9,8 @@ require "application_system_test_case"
 # provider for ASR and settling background jobs, which the integration and
 # service suites already cover without a browser.
 class PlaygroundTest < ApplicationSystemTestCase
+  include PdfFixtures
+
   # Sign in through Warden rather than the sign-in form: driving the form makes
   # every test here depend on a CSRF token surviving Turbo's page cache across
   # examples, which is a failure mode that has nothing to do with the recorder.
@@ -226,6 +228,39 @@ class PlaygroundTest < ApplicationSystemTestCase
     assert_text "Press record and describe a consultation out loud"
   end
 
+  # The one document-mode rule that only a browser can prove. The upload loop
+  # aborts on the first failure, so page 2 of 2 being refused leaves ONE page
+  # on the server — and commit's gate only needs some document attached.
+  # Re-committing there would OCR half a lab report and finish green. Retry
+  # must instead start over on a FRESH session, never touch the half-uploaded
+  # one again. This drives the real /api/v2 with real uploads: a parseable
+  # first page and a second file pdf-reader cannot read.
+  test "retrying a broken upload loop starts over on a fresh session, not the half-uploaded one" do
+    visit template_playground_path(@template)
+    click_on "Upload a report"
+    attach_file(nil, [ valid_pdf_fixture, unreadable_pdf_fixture ], make_visible: true)
+    assert_text(/2 files ready/i)
+
+    assert_difference -> { ScribeSession.where(modality: "document").count }, 1 do
+      click_on "Extract"
+      assert_text "could not be read"
+    end
+    first = ScribeSession.where(modality: "document").order(:id).last
+    assert_equal 1, first.document_files.count, "page 1 landed before page 2 was refused"
+    assert_equal "uploading", first.status
+
+    assert_difference -> { ScribeSession.where(modality: "document").count }, 1 do
+      click_on "Retry"
+      assert_text "could not be read"
+    end
+    second = ScribeSession.where(modality: "document").order(:id).last
+    assert_not_equal first.id, second.id, "retry re-used the half-uploaded session"
+    assert_equal 1, second.document_files.count
+    # The half-uploaded session was left alone: not committed, not re-uploaded to.
+    assert_equal "uploading", first.reload.status
+    assert_equal 1, first.document_files.count
+  end
+
   private
 
   # Written once per example into the test's tmp dir; content is irrelevant
@@ -234,6 +269,20 @@ class PlaygroundTest < ApplicationSystemTestCase
   def pdf_fixture
     path = Rails.root.join("tmp", "report.pdf")
     File.binwrite(path, "%PDF-1.4\n%%EOF\n")
+    path.to_s
+  end
+
+  # A PDF the server can actually parse (the upload-loop test posts it for
+  # real), and one it cannot: same header, no structure.
+  def valid_pdf_fixture
+    path = Rails.root.join("tmp", "page-1.pdf")
+    File.binwrite(path, minimal_pdf(pages: 1))
+    path.to_s
+  end
+
+  def unreadable_pdf_fixture
+    path = Rails.root.join("tmp", "page-2.pdf")
+    File.binwrite(path, "%PDF-1.4 this is not a real pdf")
     path.to_s
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,6 +10,7 @@ ENV["OPENAI_ACCESS_TOKEN"] ||= "test-openai-token"
 require_relative "../config/environment"
 require "rails/test_help"
 require "webmock/minitest"
+Dir[Rails.root.join("test/support/**/*.rb")].sort.each { |f| require f }
 
 # All external provider HTTP must be stubbed in tests.
 WebMock.disable_net_connect!(allow_localhost: true)


### PR DESCRIPTION
## Summary

An audit of the document/OCR modality found 37 issues; 8 survived adversarial verification. This fixes all 8 plus two cheap real ones, documents the flow, and gives OCR a browser surface.

The architecture was already right — OCR is modelled as a transcript-producing stage, so document sessions inherit the audio path's per-output isolation, metering and status rollup rather than forking. The problems were at the edges: the trust boundary at ingest and the completeness contract at egress.

**Upload hardening** (`f94c430`)
- **Thread-exhaustion DoS.** `count_pages` parsed untrusted PDFs unbounded on a Puma thread. pdf-reader loops an xref subsection length read straight from the file via an unbounded `to_i`, so a ~300-byte upload declaring four billion entries spins for hours. With `RAILS_MAX_THREADS` at 3, three of them take down every endpoint for every account. Now bounded at 2s.
- **Page-count spoofing.** Counts came from the self-declared `/Count`, so a 500-page report could declare itself as 1 and slip under both the 20-page cap and the per-page credit hold. Now walks the real page tree. (`#pages` is not a fix — it's `(1..page_count).map` and inherits the same lie.)
- **Cycle crash.** That walk has no cycle guard, so a self-referencing page tree raises `SystemStackError` — not a `StandardError`. Caught explicitly, with a regression test.
- **Unlocked caps.** The byte and page ceilings were a read-modify-write; concurrent uploads both passed. Now under a row lock, with the status guard re-asserted inside it.

**Completeness** (`d2a85b8`, `af67fba`)
- `Anthropic#ocr` never checked `stop_reason`, so a 200 that hit `max_tokens` persisted half a lab report as the clinical transcript — structuring read it, the session finished green. The guard now lives in `Llm::Adapter` and is raised inside the adapter, which is what lets `Llm::Caller` spend the fallback provider.
- OCR sized its output budget from the adapters' 4096-token structuring default — about three pages against a 20-page cap.
- Multi-file reports were read in arbitrary order.

**Billing** (`d2a85b8`, `af67fba`)
- Truncated and empty 200s are billed by the provider but were recorded nowhere. `Llm::Error` now carries that usage, and it's recorded as a `:failed` event — visible in the ledger, deliberately not deducted, since the UI promises a failed run costs nothing.
- `Llm::Caller` dropped the primary's error on fallback, hiding the cost of the attempt it recovered from.
- OCR dedupe keys carry an attempt number, so a retried call is billed instead of colliding with the first attempt and vanishing.

**Robustness** (`af67fba`)
- `ensure_transcript!` rescued only `Llm::Error`, but the document path also downloads blobs and writes a `Transcript` — either escaping left every output at `:pending` with no webhook and an empty error.
- Internal exception text (SQL, bucket names, filesystem paths) reached the public `errors` key; now a generic message, real detail to the log (CWE-209).
- `:document` is filtered from logs — lab reports are named after patients.

**Playground** (`d8e82e9`) — a source switch on the same card; both modes share one status line, steps, error panel and result. A failed upload loop restarts on a fresh session rather than re-committing, which would OCR a third of a report and finish green.

**Database** (`9ae50df`) — CHECK constraint on `document_pages`, `NOT VALID` with over-cap rows clamped first (an untouched one would become unwritable and 500 the session permanently).

## Test Coverage

Tests: 510 → 537 (+27), plus 4 new system tests. All new code paths covered:

- `OcrStage` — 14 new standalone cases: truncation on both providers, fallback on truncation, budget scaling/floor/cap, page grafting, request block shapes, multi-document ordering
- `/documents` — cyclic PDF, xref bomb (bounded return), `/Count` understatement, cumulative page cap, truncation failing the session, failed-attempt metering with pages, transport failure recording nothing, retry billed separately, fallback attempt billed
- Playground — document session creation, modality fallback, scope claim, limits rendered; system tests for the mode switch, file selection, client-side rejection, and switching back

## Pre-Landing Review

An adversarial subagent reviewed this diff and found 9 real issues, **all fixed before this PR**, including the `SystemStackError` 500 I introduced (confirmed end-to-end: 500 on the new code, clean 200 on the old), the `NOT VALID` constraint bricking legacy rows, the fallback dropping billed usage, the CWE-209 leak, the `pages: 0` on failed events, and the playground's partial-report retry.

Brakeman clean. Rubocop clean (276 files).

## Test plan

- [x] `bin/rails test` — 537 runs, 1965 assertions, 0 failures
- [x] `bin/rails test:system` — 9 runs, 0 failures (real headless Chrome)
- [x] `bin/rubocop` — no offenses
- [x] `bin/brakeman` — no warnings

**Known flake, pre-existing and unrelated:** `playground_test.rb:134` ("says so when nothing is being heard") fails ~1 in 4. Chrome's fake audio device is a tone, and the VAD sometimes classifies it as speech, so `seq > 0` and the hint reads "N phrases captured" instead. Not touched by this PR; passes 3/3 on clean main.

## Deferred

27 lower-severity audit findings are not in this PR. The three worth prioritizing: uploaded PHI is never purged (expiry closes the API surface, the blob stays); a document session whose job is lost wedges in `processing` with no sweeper; and `supports_vision`/`supports_pdf` are written but never read, so OCR can be pointed at a text-only model.

Structuring has the same dedupe-collision bug OCR had — `"{session}:{output}:structuring"` is stable, so re-running a failed output is unbillable. Scoped out deliberately rather than silently changing billing on the mature audio path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added document-upload and extraction mode to the playground alongside audio recording.
  - Supports multiple files, type and size validation, upload tracking, retries, and extracted text results.
  - Added modality details, usage reporting, and a complete document/OCR API workflow.

- **Bug Fixes**
  - Improved protection against upload races, invalid PDFs, excessive pages, and malformed documents.
  - Improved handling of incomplete OCR responses, retries, fallback attempts, and extraction errors.

- **Documentation**
  - Expanded API and architecture documentation for document uploads, OCR, limits, errors, and usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->