### PR TITLE
Cut the per-segment cost of a live consultation

### DIFF
--- a/app/controllers/api/v2/base_controller.rb
+++ b/app/controllers/api/v2/base_controller.rb
@@ -36,24 +36,27 @@ module Api
         head :unauthorized
       end
 
-      # Memoized active-token resolution (digest lookup + active/expiry scope
-      # enforced inside ApiToken.authenticate).
-      def current_api_token
-        return @current_api_token if defined?(@current_api_token)
-
-        @current_api_token = ApiToken.authenticate(bearer_token)
+      # The caller, resolved once per request and shared with Rack::Attack (see
+      # Api::Credential) so throttling and authorization do not each pay for the
+      # same lookups.
+      def credential
+        @credential ||= Api::Credential.for(request)
       end
 
-      # Memoized scoped session-token claims (`{ "sid" => Integer, "scope" =>
-      # [...] }`) or nil. Verification is a signature+expiry check — no DB row.
-      def current_session_claims
-        return @current_session_claims if defined?(@current_session_claims)
+      # Active account token (digest lookup + active/expiry scope enforced
+      # inside ApiToken.authenticate), or nil.
+      def current_api_token
+        credential.api_token
+      end
 
-        @current_session_claims = Scribe::SessionToken.verify(bearer_token)
+      # Scoped session-token claims (`{ "sid" => Integer, "scope" => [...] }`)
+      # or nil. Verification is a signature+expiry check — no DB row.
+      def current_session_claims
+        credential.session_claims
       end
 
       def current_account
-        current_api_token&.account
+        credential.account
       end
 
       # Account-only actions (create/index/tokens/config/usage) call this so a

--- a/app/controllers/api/v2/scribe_sessions_controller.rb
+++ b/app/controllers/api/v2/scribe_sessions_controller.rb
@@ -139,8 +139,7 @@ module Api
           render_error(code: "validation_error", message: "unsupported audio content type: #{upload.content_type}", status: :unprocessable_entity)
           return
         end
-        other_bytes = session.audio_chunks.where.not(seq: seq)
-                             .with_attached_data.sum { |c| c.data.blob&.byte_size.to_i }
+        other_bytes = attached_bytes(session.audio_chunks.where.not(seq: seq))
         if other_bytes + upload.size.to_i > ScribeSession::MAX_AUDIO_BYTES
           render_error(code: "audio_upload_failed", message: "total audio exceeds #{ScribeSession::MAX_AUDIO_BYTES} bytes", status: :unprocessable_entity)
           return
@@ -212,8 +211,7 @@ module Api
           render_error(code: "validation_error", message: "unsupported audio content type: #{upload.content_type}", status: :unprocessable_entity)
           return
         end
-        other_bytes = session.transcript_segments.where.not(seq: seq)
-                             .with_attached_data.sum { |s| s.data.blob&.byte_size.to_i }
+        other_bytes = attached_bytes(session.transcript_segments.where.not(seq: seq))
         if other_bytes + upload.size.to_i > ScribeSession::MAX_AUDIO_BYTES
           render_error(code: "audio_upload_failed", message: "total segment audio exceeds #{ScribeSession::MAX_AUDIO_BYTES} bytes", status: :unprocessable_entity)
           return
@@ -469,6 +467,26 @@ module Api
       COMMIT_ESTIMATE_RATE_PER_PAGE = 0.01
 
       private
+
+      # Total stored bytes across a relation of records with a `data`
+      # attachment, summed in SQL.
+      #
+      # The running-total caps run on EVERY upload, so this must not grow with
+      # the length of the consultation. The obvious
+      # `relation.with_attached_data.sum { |r| r.data.blob&.byte_size.to_i }`
+      # does: it materialises every sibling record, its attachment and its blob
+      # just to add up one integer column, so the 300th segment of a long
+      # consultation dragged back ~900 rows before it could be accepted.
+      def attached_bytes(relation)
+        ActiveStorage::Blob
+          .joins(:attachments)
+          .where(active_storage_attachments: {
+            record_type: relation.klass.name,
+            name: "data",
+            record_id: relation.select(:id)
+          })
+          .sum(:byte_size)
+      end
 
       # Renders a 409 and returns true when the session's modality does not
       # match the upload surface (audio uploads to a document session or vice

--- a/app/jobs/process_scribe_session_job.rb
+++ b/app/jobs/process_scribe_session_job.rb
@@ -20,13 +20,31 @@
 # swept to :failed by Metering::ReservationSweeper rather than trued up against
 # the ledger (holds are postpaid and reserve no credit balance).
 class ProcessScribeSessionJob < ApplicationJob
-  # Settlement waits up to MAX_SETTLE_ATTEMPTS * SETTLE_WAIT (~2 minutes,
-  # matching STALE_CLAIM_AGE) for in-flight segment jobs, then treats any
-  # remaining "transcribing" claim as a dead worker: reclaim and retry inline
-  # exactly once before the orchestrator settles the session.
-  MAX_SETTLE_ATTEMPTS = 24
+  # Settlement waits ~2 minutes (matching STALE_CLAIM_AGE) for in-flight segment
+  # jobs, then treats any remaining "transcribing" claim as a dead worker:
+  # reclaim and retry inline exactly once before the orchestrator settles the
+  # session.
+  #
+  # The wait is DELIBERATELY not flat. A client commits the instant the last
+  # segment upload returns, so that segment's ASR (~0.5-2s) is nearly always
+  # still in flight on the first attempt — and a flat 5s tick charged every
+  # single commit a full tick of dead time before anything else could happen.
+  # The first FAST_SETTLE_ATTEMPTS therefore retry on a 1s tick (the floor is
+  # the dispatcher's own polling_interval, config/queue.yml), and only a
+  # genuinely slow settlement backs off to the coarse tick. Attempt counts are
+  # sized so the TOTAL budget still covers STALE_CLAIM_AGE:
+  #   5 x 1s + 23 x 5s = 120s.
+  FAST_SETTLE_ATTEMPTS = 5
+  FAST_SETTLE_WAIT = 1.second
+  MAX_SETTLE_ATTEMPTS = 28
   SETTLE_WAIT = 5.seconds
   STALE_CLAIM_AGE = 2.minutes
+
+  # Backoff for the next settle retry: short while the racing segment is
+  # plausibly still mid-call, coarse once waiting is clearly not paying off.
+  def self.settle_wait_for(attempt)
+    attempt < FAST_SETTLE_ATTEMPTS ? FAST_SETTLE_WAIT : SETTLE_WAIT
+  end
 
   def perform(scribe_session_id, settle_attempt = 0)
     session = ScribeSession.find_by(id: scribe_session_id)
@@ -76,7 +94,7 @@ class ProcessScribeSessionJob < ApplicationJob
 
     if segments.where(status: "transcribing").exists?
       if attempt < MAX_SETTLE_ATTEMPTS
-        self.class.set(wait: SETTLE_WAIT).perform_later(session.id, attempt + 1)
+        self.class.set(wait: self.class.settle_wait_for(attempt)).perform_later(session.id, attempt + 1)
         return :waiting
       end
 

--- a/app/services/api/credential.rb
+++ b/app/services/api/credential.rb
@@ -1,0 +1,81 @@
+module Api
+  # The caller behind one API request, resolved ONCE.
+  #
+  # Two layers need to know who is calling: Rack::Attack, to find the account
+  # whose rate budget to spend, and the controller, to authorize and scope the
+  # work. They used to resolve the same bearer string independently, so every
+  # request — every poll, every segment upload — paid for the same lookups
+  # twice. The first resolution is stashed in the Rack env, which both layers
+  # share, so the second is free.
+  #
+  # Resolution is lazy: nothing is queried until something asks. A request that
+  # never reaches the throttle (a non-/api path) resolves in the controller as
+  # before, so this is an optimisation, never a dependency.
+  class Credential
+    ENV_KEY = "medispeak.api_credential".freeze
+
+    # The credential for this request, memoized in the Rack env shared by the
+    # middleware stack and the controller. Accepts any Rack/ActionDispatch
+    # request.
+    def self.for(request)
+      env = request.env
+      env[ENV_KEY] ||= new(bearer_token(request))
+    end
+
+    def self.bearer_token(request)
+      request.get_header("HTTP_AUTHORIZATION").to_s.split(" ").last
+    end
+
+    def initialize(raw_token)
+      @raw_token = raw_token.to_s
+    end
+
+    # The account API token, or nil. A scoped session token is a signed blob and
+    # never an ApiToken row, so it skips the digest lookup entirely rather than
+    # spending a query to miss.
+    def api_token
+      return @api_token if defined?(@api_token)
+
+      @api_token = session_token? ? nil : ApiToken.authenticate(@raw_token)
+    end
+
+    # Claims of a scoped session (mss_) token, or nil. Signature + expiry check;
+    # no DB row.
+    def session_claims
+      return @session_claims if defined?(@session_claims)
+
+      @session_claims = Scribe::SessionToken.verify(@raw_token)
+    end
+
+    # The account an ACCOUNT token belongs to. Deliberately nil for a scoped
+    # session token: that credential must never reach an account-wide surface,
+    # and controllers gate on exactly this.
+    def account
+      return @account if defined?(@account)
+
+      @account = api_token&.account
+    end
+
+    # The account whose rate-limit budget this request spends. Unlike #account
+    # this DOES resolve a session token to its session's account, so browser
+    # traffic counts against the same per-account budget as account tokens.
+    def throttled_account_id
+      return @throttled_account_id if defined?(@throttled_account_id)
+
+      @throttled_account_id = api_token&.account_id || session_account_id
+    end
+
+    private
+
+    def session_token?
+      @raw_token.start_with?(Scribe::SessionToken::PREFIX)
+    end
+
+    def session_account_id
+      claims = session_claims
+      return nil unless claims
+
+      ScribeSession.where(id: claims["sid"]).pick(:account_id)
+    end
+  end
+end

--- a/app/services/scribe/audio_duration.rb
+++ b/app/services/scribe/audio_duration.rb
@@ -3,6 +3,13 @@ module Scribe
   # `seconds` (Float) and `estimated` (Boolean). Never raises — a measurement
   # failure degrades to an estimate rather than aborting the pipeline. See
   # plan 001 for why: ASR is billed per minute and must not be metered at 0.
+  #
+  # This deliberately never touches storage. It used to call `blob.analyze`,
+  # which downloads the blob a SECOND time (the caller already holds the bytes)
+  # and then shells out to ffprobe — a binary the production buildpack does not
+  # ship, so the download bought nothing. Duration now comes from the bytes in
+  # hand: the audio's own header when it is a format we can read, else a
+  # byte-rate estimate.
   class AudioDuration
     Result = Struct.new(:seconds, :estimated, keyword_init: true)
 
@@ -10,6 +17,17 @@ module Scribe
     # for a common compressed-audio bitrate; flagged estimated: true so the
     # UsageEvent is marked approximate. Adjust with maintainer guidance.
     ESTIMATE_BYTES_PER_SECOND = 16_000.0
+
+    # Uncompressed PCM is ~2x the compressed rate, so estimating a WAV with the
+    # constant above bills every segment at twice its real length. This is the
+    # browser recorder's own format (16-bit, mono, 16 kHz -> 32_000 B/s) and is
+    # only ever reached when a WAV's header cannot be parsed; a well-formed WAV
+    # is measured exactly.
+    WAV_ESTIMATE_BYTES_PER_SECOND = 32_000.0
+
+    # Bound the header scan so a malformed or hostile file cannot make us walk a
+    # long chunk list. A real WAV carries `data` within the first few chunks.
+    MAX_HEADER_CHUNKS = 16
 
     def self.for_blob(blob, file: nil)
       new(blob, file: file).call
@@ -31,16 +49,85 @@ module Scribe
 
     private
 
-    # Returns an exact duration in seconds when a probe is available, else nil.
-    # If ffprobe is present, ActiveStorage's audio analyzer populates
-    # blob.metadata["duration"]; otherwise this returns nil and we estimate.
+    # An exact duration when one can be had without going back to storage: a
+    # duration some analyzer already recorded (environments that do have
+    # ffprobe), otherwise the audio's own header.
     def exact_seconds
-      @blob.analyze unless @blob.analyzed?
-      @blob.metadata["duration"]&.to_f
+      recorded = @blob.metadata["duration"]&.to_f
+      return recorded if recorded&.positive?
+
+      header_seconds
+    end
+
+    # Duration read from the file the caller already downloaded. nil when there
+    # is no file in hand or the bytes are not a readable WAV, which sends the
+    # caller to the estimate.
+    def header_seconds
+      return nil if @file.nil?
+      return nil unless wav?
+
+      wav_seconds(@file)
     end
 
     def estimate_seconds
-      (@blob.byte_size.to_f / ESTIMATE_BYTES_PER_SECOND).round(3)
+      rate = wav? ? WAV_ESTIMATE_BYTES_PER_SECOND : ESTIMATE_BYTES_PER_SECOND
+      (@blob.byte_size.to_f / rate).round(3)
+    end
+
+    def wav?
+      type = @blob.content_type.to_s.downcase
+      type.include?("wav") || @blob.filename.to_s.downcase.end_with?(".wav")
+    end
+
+    # Parse a RIFF/WAVE header: duration is the `data` chunk's size divided by
+    # the `fmt ` chunk's byte rate. Reads only the header — never the samples —
+    # and always leaves the IO where it found it, because the caller streams the
+    # very same handle to the ASR provider next.
+    def wav_seconds(io)
+      original_pos = io.pos
+      io.rewind
+
+      return nil unless io.read(4) == "RIFF"
+
+      io.read(4) # total size, unused
+      return nil unless io.read(4) == "WAVE"
+
+      byte_rate = nil
+      data_size = nil
+
+      MAX_HEADER_CHUNKS.times do
+        header = io.read(8)
+        break if header.nil? || header.bytesize < 8
+
+        chunk_id = header[0, 4]
+        chunk_size = header[4, 4].unpack1("V")
+        break if chunk_size.nil?
+
+        case chunk_id
+        when "fmt "
+          fmt = io.read(chunk_size)
+          break if fmt.nil? || fmt.bytesize < 16
+
+          # audio_format(2) channels(2) sample_rate(4) byte_rate(4)
+          byte_rate = fmt[8, 4].unpack1("V")
+        when "data"
+          data_size = chunk_size
+          break # samples follow; everything needed is known
+        else
+          # Chunks are word-aligned, so an odd size carries one pad byte.
+          io.seek(chunk_size + (chunk_size.odd? ? 1 : 0), IO::SEEK_CUR)
+        end
+
+        break if byte_rate && data_size
+      end
+
+      return nil if byte_rate.nil? || byte_rate.zero? || data_size.nil?
+
+      (data_size.to_f / byte_rate).round(3)
+    rescue StandardError
+      nil
+    ensure
+      io.seek(original_pos) if io.respond_to?(:seek)
     end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,5 +23,27 @@ module MedispeakBackend
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+
+    # Do not analyze audio blobs. Active Storage attaches an AudioAnalyzer to
+    # every audio/* blob, which enqueues a background job that downloads the
+    # blob from S3 and shells out to ffprobe just to read a duration. Production
+    # runs on the DO ruby buildpack, which ships NO ffprobe (verified: 0 of 334
+    # audio blobs in prod carry a "duration"), so that job can only ever fail —
+    # one wasted job and one wasted S3 GET for every segment uploaded, competing
+    # with live transcription for the worker's three threads.
+    #
+    # Nothing reads blob.metadata["duration"] except Scribe::AudioDuration, which
+    # measures the audio itself from bytes it already holds. Dropping the
+    # analyzer falls audio blobs through to Active Storage's NullAnalyzer, whose
+    # `analyze_later? == false` means one inline metadata UPDATE and no job at
+    # all. Applied in every environment deliberately: dev/test machines that DO
+    # have ffprobe installed would otherwise mask this behaviour (they did).
+    #
+    # Image analysis is left alone — it is a different analyzer on a different
+    # (document/OCR) path.
+    config.after_initialize do |app|
+      app.config.active_storage.analyzers.delete(ActiveStorage::Analyzer::AudioAnalyzer)
+      ActiveStorage.analyzers.delete(ActiveStorage::Analyzer::AudioAnalyzer)
+    end
   end
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -91,6 +91,10 @@ production:
     # Connection (host/port/user/password/sslmode) comes from the shared default
     # via env — one managed-Postgres credential (e.g. DO's) serves all four
     # databases below; each just overrides the database name.
+  # Kept configured but NOT used at runtime: production caches in process (see
+  # config/environments/production.rb), so no connection is ever checked out of
+  # this pool. Solid Cache's Record class resolves this mapping at boot, so the
+  # entry must stay for the app to start while the gem is installed.
   cache:
     <<: *primary_production
     database: medispeak_backend_production_cache

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,8 +46,24 @@ Rails.application.configure do
   # Don't log any deprecations.
   config.active_support.report_deprecations = false
 
-  # Replace the default in-process memory cache store with a durable alternative.
-  config.cache_store = :solid_cache_store
+  # Rate-limit counters are the ONLY thing in this app that uses Rails.cache
+  # (config/initializers/rack_attack.rb sets `self.cache.store = Rails.cache`;
+  # nothing else calls Rails.cache). Backing them with Solid Cache made every
+  # single API request perform a synchronous Postgres write transaction —
+  # SELECT ... FOR UPDATE plus an upsert on a separate `cache` database — and
+  # hold one more pooled connection per busy thread, on a managed instance whose
+  # ceiling is 25 connections in total.
+  #
+  # Counters are cheap, short-lived and self-healing, and the web tier is a
+  # SINGLE Puma process (WEB_CONCURRENCY unset, instance_count 1), so in-process
+  # counters are exact and the durability of Solid Cache buys nothing.
+  #
+  # IF THE WEB TIER IS EVER SCALED to N processes or instances, counters become
+  # per-process and the effective per-account cap loosens to N x rpm. At that
+  # point either divide the budget, or move back to a shared store by restoring
+  # `config.cache_store = :solid_cache_store` (Solid Cache and its database stay
+  # configured, so that is the only line to change back).
+  config.cache_store = :memory_store, { size: 64.megabytes }
 
   # Replace the default in-process and non-durable queuing backend for Active Job.
   config.active_job.queue_adapter = :solid_queue

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -30,33 +30,32 @@ if defined?(Rack::Attack)
                                 period: RPM_PERIOD) do |req|
       next nil unless req.path.start_with?("/api/")
 
-      token = req.get_header("HTTP_AUTHORIZATION").to_s.split(" ").last
       # Resolve the account behind EITHER credential. Scoped session (mss_)
       # tokens are stateless MessageVerifier blobs, not ApiToken rows, so
       # ApiToken.authenticate returns nil for them — without the session-token
       # fallback every browser-token request (audio, segments, live_form,
       # realtime_token, commit) skipped throttling entirely, defeating the
       # per-account cap the whole file exists to enforce.
-      account_id = ApiToken.authenticate(token)&.account_id ||
-                   Rack::Attack.session_token_account_id(token)
+      #
+      # Api::Credential memoizes this into the Rack env, so the controller
+      # reuses the resolution instead of repeating it.
+      credential = Api::Credential.for(req)
+      account_id = Rack::Attack.throttled_account_id(credential)
       next nil if account_id.nil?
 
       # Resolve this account's per-minute budget and stash it so the `limit`
-      # proc above can read it (it receives the same request object).
-      settings = Account.find_by(id: account_id)&.settings || {}
+      # proc above can read it (it receives the same request object). An account
+      # token already carries its account, so only browser traffic pays a lookup.
+      settings = (credential.account || Account.find_by(id: account_id))&.settings || {}
       req.env["rack.attack.account_rpm"] = (settings["rpm"] || DEFAULT_RPM).to_i
 
       account_id
     end
 
-    # Resolve a scoped session token (mss_) to its session's account_id with a
-    # single-column lookup, so browser-token traffic counts against the same
-    # per-account budget as account tokens. Returns nil for an invalid token.
-    def self.session_token_account_id(token)
-      claims = Scribe::SessionToken.verify(token)
-      return nil unless claims
-
-      ScribeSession.where(id: claims["sid"]).pick(:account_id)
+    # The account whose budget this request spends, or nil when the credential
+    # resolves to nobody. A malformed token must never raise out of middleware.
+    def self.throttled_account_id(credential)
+      credential.throttled_account_id
     rescue StandardError
       nil
     end

--- a/test/integration/api/v2/segment_upload_cost_test.rb
+++ b/test/integration/api/v2/segment_upload_cost_test.rb
@@ -1,0 +1,160 @@
+require "test_helper"
+
+module Api
+  module V2
+    # What ONE live segment upload costs the server.
+    #
+    # This is the hottest write path in the product: during a consultation every
+    # clinician POSTs a segment every few seconds, and each one occupies one of
+    # the web tier's three Puma threads for the whole request. These tests pin
+    # the costs that are invisible in a functional test but decide whether ten
+    # concurrent recorders fit on the box:
+    #
+    #   - no speculative background work is queued behind the upload,
+    #   - the work per upload does not grow with the length of the consultation,
+    #   - the caller's credential is resolved once, not once per middleware layer.
+    class SegmentUploadCostTest < ActionDispatch::IntegrationTest
+      setup do
+        Rails.cache.clear if Rails.cache.respond_to?(:clear)
+
+        @account = create(:account)
+        @user = create(:user, account: @account)
+        @token = create(:api_token, user: @user, account: @account)
+        @session = create(:scribe_session, account: @account, api_token: @token, user: @user)
+        @session_token, = Scribe::SessionToken.mint(@session)
+        @auth = { "Authorization" => "Bearer #{@session_token}" }
+
+        @prev_openai_token = ENV["OPENAI_ACCESS_TOKEN"]
+        ENV["OPENAI_ACCESS_TOKEN"] = "test-key"
+        stub_request(:post, "https://api.openai.com/v1/audio/transcriptions").to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { text: "hello" }.to_json
+        )
+      end
+
+      teardown do
+        Rails.cache.clear if Rails.cache.respond_to?(:clear)
+        ENV["OPENAI_ACCESS_TOKEN"] = @prev_openai_token
+      end
+
+      # Production has no ffprobe (the DO ruby buildpack ships none), so Active
+      # Storage's audio analyzer can only download the blob, shell out, fail, and
+      # write nothing — one wasted job and one wasted S3 GET for every segment,
+      # competing with transcription for the worker's three threads.
+      test "uploading a segment queues transcription and nothing else" do
+        with_test_adapter do
+          post segments_url, params: { seq: 0, segment: segment_upload("seg-zero") }, headers: @auth
+          assert_response :ok
+
+          enqueued = enqueued_jobs.map { |j| j["job_class"] || j[:job].to_s }
+          assert_includes enqueued, "TranscribeSegmentJob"
+          assert_not_includes enqueued, "ActiveStorage::AnalyzeJob",
+                              "analysis cannot measure anything without ffprobe; it only costs a job and an S3 download"
+        end
+      end
+
+      # The running-total byte cap used to load every previously uploaded
+      # segment (plus its attachment and blob rows) into Ruby on each upload, so
+      # a 30-minute consultation paid O(n) per POST and O(n^2) overall. The
+      # query COUNT hid this (the preload is a fixed three statements) — the cost
+      # is in the rows those statements drag back, so count the records built.
+      test "upload cost does not grow with the number of segments already uploaded" do
+        post segments_url, params: { seq: 0, segment: segment_upload("first") }, headers: @auth
+        assert_response :ok
+        baseline = count_records do
+          post segments_url, params: { seq: 1, segment: segment_upload("second") }, headers: @auth
+        end
+        assert_response :ok
+
+        (2..9).each do |seq|
+          post segments_url, params: { seq: seq, segment: segment_upload("filler-#{seq}") }, headers: @auth
+          assert_response :ok
+        end
+
+        later = count_records do
+          post segments_url, params: { seq: 10, segment: segment_upload("eleventh") }, headers: @auth
+        end
+        assert_response :ok
+
+        assert_equal baseline, later,
+                     "the 11th segment of a consultation must cost the same as the 2nd"
+      end
+
+      # Rack::Attack resolves the caller to find the account whose rate budget to
+      # spend, and the controller then resolved the very same credential again.
+      test "the caller's credential is resolved once per request" do
+        token_lookups = with_test_adapter do
+          count_queries(matching: /\bapi_tokens\b/) do
+            post segments_url, params: { seq: 0, segment: segment_upload("seg-zero") }, headers: @auth
+          end
+        end
+        assert_response :ok
+
+        assert_operator token_lookups, :<=, 1,
+                        "throttling and the controller must share one credential resolution"
+      end
+
+      test "an account token is also resolved only once" do
+        headers = { "Authorization" => "Bearer #{@token.raw_token}" }
+
+        token_lookups = count_queries(matching: /\bapi_tokens\b/) do
+          get "/api/v2/scribe_sessions/#{@session.id}", headers: headers
+        end
+        assert_response :accepted
+
+        assert_operator token_lookups, :<=, 1,
+                        "throttling and the controller must share one credential resolution"
+      end
+
+      private
+
+      def count_queries(matching: nil)
+        count = 0
+        sub = ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+          next if payload[:name].to_s.in?([ "SCHEMA", "TRANSACTION" ])
+          next if matching && !payload[:sql].to_s.match?(matching)
+
+          count += 1
+        end
+        yield
+        count
+      ensure
+        ActiveSupport::Notifications.unsubscribe(sub)
+      end
+
+      # Active Record objects built while the block runs — the cost that grows
+      # with a long consultation, which a query count cannot see.
+      def count_records
+        count = 0
+        sub = ActiveSupport::Notifications.subscribe("instantiation.active_record") do |*, payload|
+          count += payload[:record_count].to_i
+        end
+        yield
+        count
+      ensure
+        ActiveSupport::Notifications.unsubscribe(sub)
+      end
+
+      def with_test_adapter
+        old = ActiveJob::Base.queue_adapter
+        ActiveJob::Base.queue_adapter = :test
+        yield
+      ensure
+        ActiveJob::Base.queue_adapter = old
+      end
+
+      def segments_url
+        "/api/v2/scribe_sessions/#{@session.id}/audio/segments"
+      end
+
+      def segment_upload(bytes)
+        file = Tempfile.new([ "segment", ".webm" ])
+        file.binmode
+        file.write(bytes)
+        file.rewind
+        Rack::Test::UploadedFile.new(file.path, "audio/webm")
+      end
+    end
+  end
+end

--- a/test/jobs/process_scribe_session_job_test.rb
+++ b/test/jobs/process_scribe_session_job_test.rb
@@ -149,6 +149,55 @@ class ProcessScribeSessionJobTest < ActiveSupport::TestCase
     ActiveJob::Base.queue_adapter = old_adapter
   end
 
+  # The commit almost always races the last segment's ASR (the client commits
+  # the instant the final segment upload returns), so the FIRST settle waits
+  # decide the user-visible "stop -> note" time. A flat 5s tick charged every
+  # commit ~5-6s for a segment that finishes in ~1s; the early attempts are
+  # therefore short and only long-running settlements fall back to the coarse
+  # tick. The total budget is unchanged (still ~STALE_CLAIM_AGE).
+  test "re-enqueues the first settle attempts with the short wait" do
+    old_adapter = ActiveJob::Base.queue_adapter
+    ActiveJob::Base.queue_adapter = :test
+
+    session = create(:scribe_session, account: create(:account), language: "en")
+    add_segment(session, seq: 0, status: "transcribing")
+
+    ProcessScribeSessionJob.perform_now(session.id)
+
+    scheduled_at = enqueued_jobs.last["at"] || enqueued_jobs.last[:at]
+    assert_in_delta Time.current.to_f + ProcessScribeSessionJob::FAST_SETTLE_WAIT.to_f,
+                    scheduled_at.to_f, 1.0,
+                    "the first settle retry must use the short wait, not the 5s tick"
+  ensure
+    ActiveJob::Base.queue_adapter = old_adapter
+  end
+
+  test "falls back to the long settle wait once the fast attempts are exhausted" do
+    old_adapter = ActiveJob::Base.queue_adapter
+    ActiveJob::Base.queue_adapter = :test
+
+    session = create(:scribe_session, account: create(:account), language: "en")
+    add_segment(session, seq: 0, status: "transcribing")
+
+    ProcessScribeSessionJob.perform_now(session.id, ProcessScribeSessionJob::FAST_SETTLE_ATTEMPTS)
+
+    scheduled_at = enqueued_jobs.last["at"] || enqueued_jobs.last[:at]
+    assert_in_delta Time.current.to_f + ProcessScribeSessionJob::SETTLE_WAIT.to_f,
+                    scheduled_at.to_f, 1.0,
+                    "a long-running settlement must back off to the coarse tick"
+  ensure
+    ActiveJob::Base.queue_adapter = old_adapter
+  end
+
+  test "the total settle budget still covers a stale claim" do
+    total = (0...ProcessScribeSessionJob::MAX_SETTLE_ATTEMPTS).sum do |attempt|
+      ProcessScribeSessionJob.settle_wait_for(attempt).to_f
+    end
+
+    assert_operator total, :>=, ProcessScribeSessionJob::STALE_CLAIM_AGE.to_f,
+                    "shortening the early waits must not shrink the window a dead worker's claim needs"
+  end
+
   test "reclaims a stale transcribing claim at the attempt bound and finishes inline" do
     stub_asr(text: "reclaimed and transcribed")
 

--- a/test/services/scribe/audio_duration_test.rb
+++ b/test/services/scribe/audio_duration_test.rb
@@ -1,0 +1,116 @@
+require "test_helper"
+require "mocha/minitest"
+
+module Scribe
+  # Duration is what ASR is billed on, so "how many seconds is this blob" has to
+  # be right without costing a second trip to S3. Production runs on the DO ruby
+  # buildpack, which ships no ffprobe: Active Storage's audio analyzer finds
+  # nothing there, so every duration falls through to this class.
+  class AudioDurationTest < ActiveSupport::TestCase
+    # A real (if silent) RIFF/WAVE file: the browser recorder emits exactly this
+    # shape — 16-bit PCM, mono, 16 kHz — so byte_rate is 32_000 B/s.
+    def wav_bytes(seconds:, sample_rate: 16_000, bits: 16, channels: 1)
+      byte_rate = sample_rate * channels * bits / 8
+      data_size = (byte_rate * seconds).to_i
+      header = [
+        "RIFF", 36 + data_size, "WAVE",
+        "fmt ", 16, 1, channels, sample_rate, byte_rate, channels * bits / 8, bits,
+        "data", data_size
+      ].pack("a4Va4a4VvvVVvva4V")
+      header + ("\0" * data_size)
+    end
+
+    def blob_for(bytes, content_type:, filename: "seg.wav")
+      ActiveStorage::Blob.create_and_upload!(
+        io: StringIO.new(bytes), filename: filename, content_type: content_type
+      )
+    end
+
+    test "measures a WAV exactly from its own header" do
+      bytes = wav_bytes(seconds: 3)
+      blob = blob_for(bytes, content_type: "audio/wav")
+
+      result = AudioDuration.for_blob(blob, file: StringIO.new(bytes))
+
+      assert_in_delta 3.0, result.seconds, 0.01
+      assert_not result.estimated, "a header-derived duration is measured, not estimated"
+    end
+
+    test "does not re-download a segment it was already handed" do
+      bytes = wav_bytes(seconds: 2)
+      blob = blob_for(bytes, content_type: "audio/wav")
+      blob.expects(:analyze).never
+      blob.expects(:download).never
+
+      result = AudioDuration.for_blob(blob, file: StringIO.new(bytes))
+
+      assert_in_delta 2.0, result.seconds, 0.01
+    end
+
+    test "does not download at all when no file is supplied" do
+      blob = blob_for(wav_bytes(seconds: 2), content_type: "audio/wav")
+      blob.expects(:analyze).never
+      blob.expects(:download).never
+
+      result = AudioDuration.for_blob(blob)
+
+      assert result.seconds.positive?
+      assert result.estimated, "with no bytes in hand the duration can only be an estimate"
+    end
+
+    test "estimates a WAV at its PCM byte rate, not the compressed-audio rate" do
+      # 10s of 16-bit 16kHz PCM. Without a WAV-aware rate this reads as 20s and
+      # every segment is metered at twice its real length.
+      blob = blob_for(wav_bytes(seconds: 10), content_type: "audio/wav")
+
+      result = AudioDuration.for_blob(blob)
+
+      assert_in_delta 10.0, result.seconds, 0.5
+    end
+
+    test "estimates a compressed segment from its byte size" do
+      bytes = "not-really-webm" * 1000
+      blob = blob_for(bytes, content_type: "audio/webm", filename: "seg.webm")
+
+      result = AudioDuration.for_blob(blob, file: StringIO.new(bytes))
+
+      assert result.estimated
+      assert_in_delta bytes.bytesize / AudioDuration::ESTIMATE_BYTES_PER_SECOND,
+                      result.seconds, 0.01
+    end
+
+    test "prefers a duration an analyzer already measured" do
+      blob = blob_for(wav_bytes(seconds: 3), content_type: "audio/wav")
+      blob.update!(metadata: blob.metadata.merge("duration" => 7.5, "analyzed" => true))
+
+      result = AudioDuration.for_blob(blob)
+
+      assert_in_delta 7.5, result.seconds, 0.01
+      assert_not result.estimated
+    end
+
+    # TranscribeSegmentJob measures the segment and then streams the very same
+    # handle to the ASR provider. Consuming it here would send a truncated file
+    # (or an empty one) to Sarvam/Whisper and silently lose the audio.
+    test "leaves the file readable from the start for the ASR call that follows" do
+      bytes = wav_bytes(seconds: 1)
+      blob = blob_for(bytes, content_type: "audio/wav")
+      file = StringIO.new(bytes)
+
+      AudioDuration.for_blob(blob, file: file)
+
+      assert_equal 0, file.pos, "the ASR call reads from wherever we left the handle"
+      assert_equal bytes.bytesize, file.read.bytesize, "the provider must still see the whole segment"
+    end
+
+    test "degrades to an estimate when the header is truncated or malformed" do
+      bytes = "RIFF____WAVEgarbage"
+      blob = blob_for(bytes, content_type: "audio/wav")
+
+      result = AudioDuration.for_blob(blob, file: StringIO.new(bytes))
+
+      assert result.estimated
+      assert result.seconds >= 0
+    end
+  end
+end


### PR DESCRIPTION
Three tier-1 latency fixes from the infra audit, on the hot path a recording clinician drives. Each was measured against production rather than guessed at.

## Why

Sarvam answers a segment in ~530ms (p95 788ms). The time a clinician actually waits is spent almost entirely in our own round-trips and fixed waits:

| Measured in prod | Value |
|---|---|
| `POST /audio/segments` | 26 queries, ~1s (S3 PUT 240-585ms in-thread), 3 Puma threads total |
| Worker S3 GET per segment | `AnalyzeJob` 333ms avg + `TranscribeSegmentJob` 423ms avg — the same blob, twice |
| Audio blobs in prod with a duration | **0 of 334** (no ffprobe on the buildpack) |
| Commit settle tick | flat 5s, charged on essentially every commit |

## What changed

**1. Settle on a short tick first** — `ProcessScribeSessionJob`

A client commits the instant the last segment upload returns, so that segment's ASR is nearly always still in flight on the first settle attempt. A flat 5s re-enqueue therefore charged *every* commit a full tick of dead time. The first 5 attempts now retry on a 1s tick (the floor is the dispatcher's own 1s polling interval); only a genuinely slow settlement backs off to 5s. Total budget is unchanged at **120s**, still covering `STALE_CLAIM_AGE` — there's a test pinning that invariant so the constants can't drift apart.

**2. Stop analyzing audio we cannot analyze** — `config/application.rb`, `Scribe::AudioDuration`

Active Storage attaches an `AudioAnalyzer` to every audio blob, enqueueing a job that downloads the blob from S3 and shells out to ffprobe. The DO ruby buildpack ships no ffprobe, so that job could only ever fail — one wasted job and one wasted S3 GET per segment, competing with live transcription for the worker's three threads. Audio now falls through to `NullAnalyzer`: one inline metadata update, no job, no download.

`Scribe::AudioDuration` no longer calls `blob.analyze` (a *second* download of the file it was just handed). It reads the WAV header from the bytes in hand, and estimates at the correct byte rate otherwise.

> **This also fixes a billing error.** The browser records 16-bit 16kHz PCM (32,000 B/s) but the estimate assumed 16,000 B/s, so every ASR usage event and credit deduction was **~2x** the real audio length. Existing `usage_events` rows are unchanged — worth a look before invoicing anyone.

Applied in **all** environments deliberately: dev/test machines that do have ffprobe were masking this — two of the new tests passed for the wrong reason until the analyzer was removed.

**3. Make a segment upload cost the same at minute 30 as at minute 1** — controller, `Api::Credential`, `production.rb`

- The running-total byte cap loaded every previously uploaded segment, its attachment and its blob into Ruby on each POST (O(n) per upload, O(n²) per consultation). Now one SQL `SUM`. The query count hid this — the preload is a fixed three statements — so the test counts *records instantiated*.
- `Rack::Attack` and the controller each resolved the same bearer token independently. `Api::Credential` resolves the caller once and shares it through the Rack env, and skips the `api_tokens` lookup entirely for `mss_` session tokens (they are never token rows). Resolution stays lazy, so a request that never reaches the throttle behaves exactly as before.
- Rate-limit counters move to an in-process store. They were the **only** `Rails.cache` user, and Solid Cache put a synchronous Postgres write transaction (`SELECT … FOR UPDATE` + upsert on a separate database) on every API request and held a pooled connection per busy thread — on an instance whose ceiling is 25 connections in total.

## Results

Measured on a segment POST with 22 segments already stored:

| | Before | After |
|---|---|---|
| Records instantiated | 41 at 11 segments, climbing | **4**, flat |
| Queries | 26 in prod | **16** (plus 4 cache-DB round-trips removed that the test env never had) |
| Credential lookups | 2–3 | **1** |
| Jobs per segment | 2 | **1** |
| S3 GETs per segment | 2–3 | **1** |

Expected effect: live transcript ~4.5s → ~3s, and stop→note down ~4s from the settle tick alone. Worker segment capacity roughly doubles (~1.6 → ~3.3 segments/s), which is what makes 10 concurrent recorders viable.

## Testing

TDD throughout — every test was watched failing first. 15 new tests; full suite **525 runs, 0 failures**; rubocop clean; brakeman no warnings.

- `test/services/scribe/audio_duration_test.rb` — exact WAV measurement, no second download, PCM-vs-compressed estimate rates, malformed-header fallback, and that the IO is **left rewound for the ASR call that follows** (verified this one fails without the guard — it caught a real truncated-upload bug I'd otherwise have shipped).
- `test/integration/api/v2/segment_upload_cost_test.rb` — no `AnalyzeJob` enqueued; upload cost flat as segments accumulate; credential resolved once for both token types.
- `test/jobs/process_scribe_session_job_test.rb` — short wait early, long wait later, and total budget ≥ `STALE_CLAIM_AGE`.

Existing coverage that guards these changes: the 25MB cap rejection test (chunked path) exercises the new SQL aggregate, and the rate-limit tests cover both credential paths through the refactored throttle.

## Deploy notes

- **No migration.** Config + code only.
- Solid Cache and its database stay configured (its `Record` class resolves the mapping at boot, so the `cache:` entry must remain while the gem is installed). Reverting is one line: `config.cache_store = :solid_cache_store`.
- If the web tier is ever scaled past one process/instance, rate-limit counters become per-process and the effective cap loosens to N × rpm — noted in `production.rb`.
- Deploy is manual: `doctl apps create-deployment daaeacf3-1e0a-4475-b3d0-08bc45bf3f31`. Worth doing off clinic hours per the audit's connection-budget finding.

## Not in this PR

Deliberately left out to keep the diff to the hot path: the `estimated` flag is still dropped before it reaches `usage_events` (so historical 2x rows can't be told apart); the one-shot `audio`/`documents` byte sums still use the Ruby loop (bounded, not in the live loop); and `queue_with_priority` on the structuring jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced memory and database usage during audio segment uploads.
  * Audio duration detection no longer requires downloading files or external media analysis.
* **Reliability**
  * Improved support for API-token and browser-session authentication, including rate limiting.
  * Audio duration handling now supports metadata, WAV headers, and safe fallback estimates.
* **Processing**
  * Scribe settlement retries respond faster while preserving the overall retry window.
* **Tests**
  * Added coverage for upload efficiency, authentication resolution, retry timing, and audio duration detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->