### PR TITLE
Fix the admin playground 422, and give OCR real models

### DIFF
--- a/app/controllers/playground_controller.rb
+++ b/app/controllers/playground_controller.rb
@@ -41,7 +41,7 @@ class PlaygroundController < ApplicationController
     end
 
     result = Scribe::SessionBuilder.new(
-      account: current_account,
+      account: playground_account,
       user: current_user,
       outputs: @pages_with_fields.map { |page| { type: "form", page_id: page.id } },
       mode: "consultation",
@@ -139,5 +139,31 @@ class PlaygroundController < ApplicationController
   # value with an error the playground has no useful way to explain.
   def modality
     MODALITIES.include?(params[:modality]) ? params[:modality] : "audio"
+  end
+
+  # The account a playground run belongs to: the one that owns the TEMPLATE,
+  # not whoever is driving the browser.
+  #
+  # For every ordinary user these are the same account — TemplatePolicy#show?
+  # only lets you open a template your own account owns. They differ for an
+  # ADMIN, who may open any tenant's template (`owned_or_admin?` returns true
+  # for admins, and the policy scope returns every template). Building the
+  # session under the admin's own account then made SessionBuilder reject the
+  # template's own pages: its tenancy check scopes page_id to
+  # `templates.account_id IN (NULL, caller_account)`, deliberately, so the
+  # public API cannot read another tenant's schema. Every admin playground run
+  # therefore 422'd with "page_id N does not reference an existing page" —
+  # after rendering a page full of fields, which made it look like a bug in the
+  # run rather than in who the run belonged to.
+  #
+  # Attributing it to the template's account is also the only way the
+  # playground tells the truth: ConfigResolver walks the account tree to pick
+  # the model assignments, so a run under a different account would exercise
+  # different models than the template really uses, and its metering would land
+  # on a tenant that never touched it. A legacy template with no account
+  # (account_id NULL) still falls back to the caller, which the tenancy check
+  # already allows.
+  def playground_account
+    @template.account || current_account
   end
 end

--- a/db/migrate/20260817120000_provision_openrouter_ocr_models.rb
+++ b/db/migrate/20260817120000_provision_openrouter_ocr_models.rb
@@ -1,0 +1,30 @@
+# Adds the OpenRouter vision models as selectable OCR options and points the
+# System-wide OCR default at the best of them.
+#
+# Until now no ModelAssignment existed for :ocr at any scope, so every document
+# session fell through ConfigResolver to Llm::DefaultConfigProvider — the
+# ENV-configured gpt-4o-mini on OpenAI direct. That is a general-purpose model
+# picked as a default for structuring, it caps completions at 16,384 tokens
+# (so OcrStage's page-sized budget gets clamped on a long report), and nothing
+# about it was chosen for reading lab reports.
+#
+# Same idempotent pattern as ProvisionOpenrouterModels: the catalog lives in
+# lib/openrouter_catalog.rb (shared with db/seeds.rb), rows are only created
+# when missing, and the assignment step will not overwrite an operator who has
+# already chosen an OCR model.
+class ProvisionOpenrouterOcrModels < ActiveRecord::Migration[8.1]
+  def up
+    OpenrouterCatalog.provision!
+    assignment = OpenrouterCatalog.assign_default_ocr!
+    if assignment
+      say "System OCR default: #{assignment.ai_model.api_model_id} " \
+          "(fallback: #{assignment.fallback_ai_model&.api_model_id || 'none'})"
+    else
+      say "System OCR default left unchanged"
+    end
+  end
+
+  def down
+    # Configuration rows; leave them in place.
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_17_093000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_17_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -371,6 +371,12 @@ ModelAssignment.find_or_create_by!(scope_type: "System", scope_id: nil, function
   a.ai_model = gpt_4_1_mini_model
 end
 
+# Document (OCR) default: a vision model chosen for reading lab reports, with a
+# different-vendor fallback. Without this, ConfigResolver falls through to the
+# ENV default — a structuring model that happens to see images, whose 16k
+# output ceiling clamps a long report. See lib/openrouter_catalog.rb.
+OpenrouterCatalog.assign_default_ocr!
+
 # Demonstration Page-scoped assignment showing mix-and-match across providers:
 # the "Consultation Form" page uses open-source Llama 3.3 70B (via OpenRouter)
 # for structuring, while ASR still resolves to OpenAI Whisper from the System

--- a/lib/openrouter_catalog.rb
+++ b/lib/openrouter_catalog.rb
@@ -22,6 +22,8 @@ module OpenrouterCatalog
   STRUCTURING_CAPABILITIES = {
     "can_structure" => true, "supports_json_schema" => true, "supports_function_calling" => true
   }.freeze
+  # Base OCR capabilities; each model adds its own "max_output_tokens" below.
+  OCR_CAPABILITIES = { "supports_vision" => true, "supports_pdf" => true }.freeze
 
   # api_model_id => { display_name:, price_per_minute: }
   ASR_MODELS = {
@@ -47,6 +49,63 @@ module OpenrouterCatalog
     "nvidia/nemotron-3-super-120b-a12b" => { display_name: "Nemotron 3 Super 120B (OpenRouter)", input_per_million: 0.085, output_per_million: 0.40 },
     "nvidia/nemotron-3.5-lightning" => { display_name: "Nemotron 3.5 Lightning (OpenRouter)", input_per_million: 0.10, output_per_million: 0.25 }
   }.freeze
+
+  # Vision models for the document (OCR) modality.
+  #
+  # Selection criteria, in order:
+  #   1. Accepts BOTH image and file input. Llm::Adapters::OpenaiCompatible#ocr
+  #      sends a PDF as OpenRouter's `type: "file"` part and a photo as
+  #      `image_url`, so a model that takes only images cannot serve a PDF
+  #      upload at all. Verified against the live /api/v1/models catalogue.
+  #   2. A large output budget. OcrStage asks for 2000 tokens per page (up to
+  #      MAX_MAX_TOKENS = 32k), and Llm::Adapter clamps that to the model's
+  #      ceiling — so a model with a small ceiling silently truncates a long
+  #      report into a fallback attempt. Every model here clears 32k, which is
+  #      why max_output_tokens is recorded on the row: without it the adapter
+  #      assumes its conservative default (16,384) and a 20-page report gets
+  #      clamped for no reason.
+  #   3. Vendor diversity, so the fallback is genuinely independent of the
+  #      primary rather than the same weights behind a different name.
+  #
+  # `max_tokens` (not `max_completion_tokens`) is what OpenRouter wants, which
+  # is what the adapter sends for any non-api.openai.com host. Confirmed present
+  # in each model's supported_parameters.
+  #
+  # api_model_id => { display_name:, input_per_million:, output_per_million:, max_output_tokens: }
+  OCR_MODELS = {
+    # The default (see the assignment in the provisioning migration). Google's
+    # current flagship Flash — `google/gemini-flash-latest` resolves to this
+    # same price point — and the Flash line is the workhorse for dense document
+    # extraction: 1M context, strong on tables, an order of magnitude cheaper
+    # than the Pro tier. Already trusted here for structuring.
+    "google/gemini-3.7-flash" => {
+      display_name: "Gemini 3.7 Flash (OpenRouter)",
+      input_per_million: 0.375, output_per_million: 1.875, max_output_tokens: 65_536
+    },
+    # The fallback: a different vendor, so a Google outage or refusal is
+    # answered by something that does not share its failure mode. Cheaper in,
+    # dearer out, and the largest output budget of the four.
+    "openai/gpt-5-mini" => {
+      display_name: "GPT-5 Mini (OpenRouter)",
+      input_per_million: 0.25, output_per_million: 2.00, max_output_tokens: 128_000
+    },
+    # Cheapest of the four: for accounts running high volume on legible,
+    # typeset reports where the Flash tier is more model than the job needs.
+    "google/gemini-3.1-flash-lite" => {
+      display_name: "Gemini 3.1 Flash Lite (OpenRouter)",
+      input_per_million: 0.25, output_per_million: 1.50, max_output_tokens: 65_536
+    },
+    # The accuracy option, and a third vendor: worth the ~2.7x input price on
+    # handwriting and poor phone photographs.
+    "anthropic/claude-haiku-4.5" => {
+      display_name: "Claude Haiku 4.5 (OpenRouter)",
+      input_per_million: 1.00, output_per_million: 5.00, max_output_tokens: 64_000
+    }
+  }.freeze
+
+  # The System-scope OCR default and its fallback. Keys into OCR_MODELS.
+  DEFAULT_OCR_MODEL = "google/gemini-3.7-flash".freeze
+  DEFAULT_OCR_FALLBACK_MODEL = "openai/gpt-5-mini".freeze
 
   # Idempotent: creates only what is missing and never overwrites an
   # operator's existing model or price rows. Returns the provider.
@@ -82,6 +141,54 @@ module OpenrouterCatalog
       end
     end
 
+    OCR_MODELS.each do |api_model_id, attrs|
+      model = AiModel.find_or_create_by!(ai_provider: provider, api_model_id: api_model_id) do |m|
+        m.display_name = attrs[:display_name]
+        m.capabilities = OCR_CAPABILITIES.merge("max_output_tokens" => attrs[:max_output_tokens])
+      end
+      # One AiModel row per (provider, api_model_id), and some of these models
+      # are ALSO in STRUCTURING_MODELS — that loop runs first and creates the
+      # row with structuring capabilities only, so the block above never runs
+      # and the vision keys would be missing. The same is true of any row an
+      # operator created by hand. Fill in only the keys that are ABSENT: a
+      # model that can structure can also read a document, and adding a
+      # capability it demonstrably has is not overwriting anyone's choice —
+      # whereas leaving max_output_tokens unset makes the adapter fall back to
+      # its conservative ceiling and clamp every long report.
+      desired = OCR_CAPABILITIES.merge("max_output_tokens" => attrs[:max_output_tokens])
+      missing = desired.reject { |key, _| model.capabilities.key?(key) }
+      model.update!(capabilities: model.capabilities.merge(missing)) if missing.any?
+      # Token prices only. Vision providers bill OCR by tokens (the image is
+      # charged as input tokens), and PriceBook adds a DocumentModelPrice
+      # per-page component ON TOP of the token cost when a row exists — so
+      # writing one here would bill these models twice for the same call.
+      ModelPrice.find_or_create_by!(provider: PROVIDER_NAME, model: api_model_id) do |price|
+        price.input_per_million = attrs[:input_per_million]
+        price.output_per_million = attrs[:output_per_million]
+        price.currency = "USD"
+        price.effective_at = now
+      end
+    end
+
     provider
+  end
+
+  # Points the System-scope OCR default at DEFAULT_OCR_MODEL, with a
+  # different-vendor fallback. Separate from #provision! because it changes a
+  # DEFAULT rather than adding a selectable option: it creates the assignment
+  # only when the function has none, so an operator who has already chosen an
+  # OCR model keeps it. Returns the assignment, or nil if the models are absent.
+  def self.assign_default_ocr!
+    provider = AiProvider.find_by(name: PROVIDER_NAME)
+    return nil unless provider
+
+    model = AiModel.find_by(ai_provider: provider, api_model_id: DEFAULT_OCR_MODEL)
+    fallback = AiModel.find_by(ai_provider: provider, api_model_id: DEFAULT_OCR_FALLBACK_MODEL)
+    return nil unless model
+
+    ModelAssignment.find_or_create_by!(scope_type: "System", scope_id: nil, function: "ocr") do |a|
+      a.ai_model = model
+      a.fallback_ai_model = fallback
+    end
   end
 end

--- a/test/controllers/playground_controller_test.rb
+++ b/test/controllers/playground_controller_test.rb
@@ -157,6 +157,65 @@ class PlaygroundControllerTest < ActionDispatch::IntegrationTest
     assert_includes claims["scope"], "document"
   end
 
+  # Production, 2026-08-17: an admin opened another tenant's template in the
+  # playground and every run 422'd. TemplatePolicy#show? returns true for any
+  # admin, so the page rendered with all its fields; SessionBuilder then scoped
+  # page_id to the CALLER's account (its tenancy check, which the public API
+  # depends on) and rejected the template's own page as non-existent. The run
+  # belongs to the account that owns the template.
+  test "an admin can run the playground on another account's template" do
+    admin = create(:user)
+    admin.update!(admin: true)
+    sign_in admin
+
+    other_page = create(:page, template: @other_template, name: "Their history")
+    create(:form_field, page: other_page, title: "chief_complaint",
+                        friendly_name: "Chief complaint", field_type: "string")
+
+    get template_playground_path(@other_template)
+    assert_response :success, "an admin may open another tenant's template"
+
+    assert_difference "ScribeSession.count", 1 do
+      post template_playground_sessions_path(@other_template), as: :json
+    end
+    assert_response :created
+
+    session = ScribeSession.find(JSON.parse(response.body)["session_id"])
+    assert_equal @other_account, session.account,
+                 "the run belongs to the template's account, not the admin's"
+    assert_equal admin, session.user, "and records who actually ran it"
+    assert_equal [ other_page.id ], session.scribe_outputs.map(&:page_id)
+  end
+
+  test "a document run on another account's template works the same way" do
+    admin = create(:user)
+    admin.update!(admin: true)
+    sign_in admin
+
+    other_page = create(:page, template: @other_template, name: "Their history")
+    create(:form_field, page: other_page, title: "chief_complaint",
+                        friendly_name: "Chief complaint", field_type: "string")
+
+    post template_playground_sessions_path(@other_template),
+         params: { modality: "document" }, as: :json
+
+    assert_response :created
+    session = ScribeSession.find(JSON.parse(response.body)["session_id"])
+    assert_equal "document", session.modality
+    assert_equal @other_account, session.account
+  end
+
+  # A non-admin is unchanged: they can only reach their own template, so the
+  # session's account is their own either way.
+  test "an ordinary user's run still belongs to their own account" do
+    sign_in @user
+    post template_playground_sessions_path(@template), as: :json
+
+    assert_response :created
+    session = ScribeSession.find(JSON.parse(response.body)["session_id"])
+    assert_equal @account, session.account
+  end
+
   test "create_session returns a scoped token that verifies for this session" do
     sign_in @user
     post template_playground_sessions_path(@template)

--- a/test/lib/openrouter_catalog_test.rb
+++ b/test/lib/openrouter_catalog_test.rb
@@ -29,6 +29,85 @@ class OpenrouterCatalogTest < ActiveSupport::TestCase
     end
   end
 
+  test "provision! creates every OCR model with vision capabilities, an output ceiling, and a token price" do
+    provider = OpenrouterCatalog.provision!
+
+    OpenrouterCatalog::OCR_MODELS.each do |slug, attrs|
+      model = AiModel.find_by!(ai_provider: provider, api_model_id: slug)
+      assert model.capability?(:supports_vision), slug
+      assert model.capability?(:supports_pdf), slug
+      # Some of these are structuring models too; that loop creates the shared
+      # row first, so the vision keys have to be merged in rather than set.
+      if OpenrouterCatalog::STRUCTURING_MODELS.key?(slug)
+        assert model.capability?(:can_structure), "#{slug} lost its structuring capability"
+      else
+        assert_equal attrs[:display_name], model.display_name
+      end
+
+      # The adapter reads this to decide how far it may let OcrStage's
+      # page-sized budget through; without it every long report is clamped to
+      # the adapter's conservative default.
+      ceiling = model.capabilities["max_output_tokens"]
+      assert_equal attrs[:max_output_tokens], ceiling, slug
+      assert_operator ceiling, :>=, Scribe::OcrStage::MAX_MAX_TOKENS,
+                      "#{slug} cannot deliver a full-cap document"
+
+      price = ModelPrice.current.find_by(provider: "OpenRouter", model: slug)
+      assert price, "token price for #{slug}"
+      assert_operator price.input_per_million, :>, 0
+      # OCR bills on tokens here; a DocumentModelPrice row would be charged ON
+      # TOP of that by PriceBook, i.e. billed twice for one call.
+      assert_nil DocumentModelPrice.current.find_by(provider: "OpenRouter", model: slug),
+                 "#{slug} must not carry a per-page price as well"
+    end
+  end
+
+  test "assign_default_ocr! points the System default at the chosen model with a different-vendor fallback" do
+    OpenrouterCatalog.provision!
+    assignment = OpenrouterCatalog.assign_default_ocr!
+
+    assert_equal "System", assignment.scope_type
+    assert_nil assignment.scope_id
+    assert_equal OpenrouterCatalog::DEFAULT_OCR_MODEL, assignment.ai_model.api_model_id
+    assert_equal OpenrouterCatalog::DEFAULT_OCR_FALLBACK_MODEL, assignment.fallback_ai_model.api_model_id
+    assert_not_equal assignment.ai_model.api_model_id.split("/").first,
+                     assignment.fallback_ai_model.api_model_id.split("/").first,
+                     "the fallback must not share the primary's vendor"
+
+    # What a document session actually resolves to, fallback included.
+    cfg = Llm::ConfigResolver.call(function: :ocr)
+    assert_equal OpenrouterCatalog::DEFAULT_OCR_MODEL, cfg.api_model_id
+    assert_equal "https://openrouter.ai/api/", cfg.base_url
+    assert_equal OpenrouterCatalog::DEFAULT_OCR_FALLBACK_MODEL, cfg.fallback.api_model_id
+    assert_equal OpenrouterCatalog::OCR_MODELS[OpenrouterCatalog::DEFAULT_OCR_MODEL][:max_output_tokens],
+                 cfg.capabilities[:max_output_tokens]
+  end
+
+  test "assign_default_ocr! leaves an operator's existing OCR choice alone" do
+    provider = OpenrouterCatalog.provision!
+    chosen = AiModel.find_by!(ai_provider: provider, api_model_id: "anthropic/claude-haiku-4.5")
+    create(:model_assignment, scope_type: "System", scope_id: nil, function: "ocr", ai_model: chosen)
+
+    assert_no_difference("ModelAssignment.count") { OpenrouterCatalog.assign_default_ocr! }
+    assert_equal "anthropic/claude-haiku-4.5", Llm::ConfigResolver.call(function: :ocr).api_model_id
+  end
+
+  test "the OCR default is priced end to end for a real document run" do
+    OpenrouterCatalog.provision!
+    OpenrouterCatalog.assign_default_ocr!
+    slug = OpenrouterCatalog::DEFAULT_OCR_MODEL
+    attrs = OpenrouterCatalog::OCR_MODELS[slug]
+
+    # A 12-page report: ~20k input tokens of image, ~9k of extracted markdown.
+    pricing = Metering::PriceBook.cost(function: :ocr, provider: "OpenRouter", model: slug,
+                                       usage: Llm::Usage.new(input_tokens: 20_000, output_tokens: 9_000, pages: 12))
+    expected = (20_000 / 1_000_000.0 * attrs[:input_per_million]) +
+               (9_000 / 1_000_000.0 * attrs[:output_per_million])
+    assert_in_delta expected, pricing[:cost], 1e-6
+    assert_operator pricing[:cost], :>, 0, "a metered OCR run must not price at zero"
+    assert_nil pricing[:unit_price_page], "no per-page component is configured for a token-billed model"
+  end
+
   test "provision! is idempotent and never overwrites existing rows" do
     provider = OpenrouterCatalog.provision!
     slug = OpenrouterCatalog::ASR_MODELS.keys.first

--- a/test/system/flash_test.rb
+++ b/test/system/flash_test.rb
@@ -1,0 +1,59 @@
+require "application_system_test_case"
+
+# Flash messages are dismissible (issue #76). The dismiss button is pure
+# client-side behaviour — a Stimulus action that removes the enclosing
+# `.notice` — so it cannot be covered anywhere but a real browser.
+#
+# The control is an icon button carrying only `aria-label="Dismiss"`, which
+# Capybara does not match from `click_button` unless enable_aria_label is set,
+# hence the explicit selector below.
+class FlashTest < ApplicationSystemTestCase
+  include Warden::Test::Helpers
+
+  DISMISS = "#flash button[aria-label='Dismiss']".freeze
+
+  setup do
+    Warden.test_mode!
+    @user = create(:user)
+    login_as @user, scope: :user
+  end
+
+  teardown { Warden.test_reset! }
+
+  # Visiting another account's template redirects to root with an alert — a
+  # real flash raised by the app, not one staged for the test.
+  def trigger_alert
+    other = create(:template, account: create(:account), name: "Someone else's")
+    visit template_playground_path(other)
+  end
+
+  test "an alert can be dismissed without reloading the page" do
+    trigger_alert
+    assert_text "You are not authorized to do that."
+    assert_selector "#flash .notice"
+
+    find(DISMISS).click
+
+    assert_no_selector "#flash .notice"
+    assert_no_text "You are not authorized to do that."
+    # Dismissed in the browser, not by navigating away: the URL must not move.
+    assert_equal root_path, URI.parse(page.current_url).path
+  end
+
+  test "the dismiss control is labelled for assistive tech and cannot submit a form" do
+    trigger_alert
+    assert_selector "#flash button[type='button'][aria-label='Dismiss']"
+  end
+
+  test "a notice raised by signing in is dismissible too" do
+    Warden.test_reset!
+    visit new_user_session_path
+    fill_in "Email", with: @user.email
+    fill_in "Password", with: "password123"
+    click_button "Log in"
+
+    assert_selector "#flash .notice"
+    find(DISMISS).click
+    assert_no_selector "#flash .notice"
+  end
+end


### PR DESCRIPTION
## The playground 422

An admin opening another tenant's template in the playground got a page full of
fields and then **422 on every run** — `page_id N does not reference an existing
page`. Seen in production at 23:49 and 23:52 UTC on template 4.

`TemplatePolicy#show?` returns true for any admin, so the page renders. The
session was then built under the **admin's** account, while `SessionBuilder`
scopes `page_id` to `templates.account_id IN (NULL, caller_account)` — a
deliberate tenancy check the public API depends on — so the template's own page
came back as non-existent.

The run now belongs to the account that **owns the template**. Nothing changes
for an ordinary user: they can only open their own template, so it is the same
account they already had. It is also the only honest attribution, since
`ConfigResolver` walks the account tree to pick the model assignments — a run
under a different account would exercise different models than the template
really uses.

Not a regression from the OCR release: it is modality-independent and predates
it. Confirmed from prod data — the template's owner created document sessions
on the same page successfully; only the cross-account admin path fails.

## OCR models

There was no `ModelAssignment` for `:ocr` at any scope, so every document
session fell through to the ENV default — `gpt-4o-mini` on OpenAI direct, a
model picked for structuring, whose 16,384-token ceiling clamps a long report.

Four vision models, chosen against OpenRouter's **live catalogue** rather than
from memory. Each takes both image and file input (the adapter sends a PDF as a
`file` part, a photo as `image_url`) and each clears `OcrStage`'s 32k cap, so a
full 20-page document is deliverable:

| model | in / out per M | max output | role |
| --- | --- | --- | --- |
| `google/gemini-3.7-flash` | $0.375 / $1.875 | 65,536 | **default** |
| `openai/gpt-5-mini` | $0.25 / $2.00 | 128,000 | fallback |
| `google/gemini-3.1-flash-lite` | $0.25 / $1.50 | 65,536 | cheap tier |
| `anthropic/claude-haiku-4.5` | $1.00 / $5.00 | 64,000 | accuracy tier |

The default is the current Flash flagship (`gemini-flash-latest` resolves to the
same price point); the fallback is a **different vendor**, so it does not share
the primary's failure mode.

Two of these are already `STRUCTURING_MODELS` and one `AiModel` row serves both,
so the vision keys are **merged into the existing row** — `find_or_create_by!`'s
block never runs for a row that exists, which would have left the default model
with no `max_output_tokens` and silently clamped every long report. Only absent
keys are filled, so operator edits stand. Token prices only: `PriceBook` adds a
`DocumentModelPrice` per-page charge *on top of* tokens, so a per-page row would
bill these twice.

The assignment step will not overwrite an operator who has already chosen an OCR
model.

## Test plan

- [x] `bin/rails test` — 612 runs, 2225 assertions, 0 failures
- [x] `bin/rails test:system` — 10 runs, 0 failures
- [x] `bin/rubocop` — clean (288 files)
- [x] `bin/brakeman` — 0 warnings
- [x] New tests fail without their fixes (verified both: the 422 reproduces
      verbatim, and the capability merge catches the shared-row case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
