### PR TITLE
Refactor modality handling in ScribeSession and SessionBuilder 

### DIFF
--- a/app/controllers/api/v2/scribe_sessions_controller.rb
+++ b/app/controllers/api/v2/scribe_sessions_controller.rb
@@ -94,6 +94,8 @@ module Api
           return
         end
 
+        return if claim_modality_or_reject(session, "audio")
+
         # Attach with the normalized (parameter-stripped) content-type so the
         # blob passes the model's audio-type validation and ASR sees a clean type.
         session.audio_files.attach(
@@ -144,6 +146,8 @@ module Api
           render_error(code: "audio_upload_failed", message: "total audio exceeds #{ScribeSession::MAX_AUDIO_BYTES} bytes", status: :unprocessable_entity)
           return
         end
+
+        return if claim_modality_or_reject(session, "audio")
 
         chunk = session.audio_chunks.find_or_initialize_by(seq: seq)
         chunk.content_type = content_type
@@ -216,6 +220,8 @@ module Api
           render_error(code: "audio_upload_failed", message: "total segment audio exceeds #{ScribeSession::MAX_AUDIO_BYTES} bytes", status: :unprocessable_entity)
           return
         end
+
+        return if claim_modality_or_reject(session, "audio")
 
         segment = session.transcript_segments.find_or_initialize_by(seq: seq)
         segment.content_type = content_type
@@ -296,6 +302,7 @@ module Api
         # ones this action was dispatched with.
         rejection = nil
         too_late = false
+        wrong_modality = false
         session.with_lock do
           # The status guard above is only a fast path: counting pages can take
           # up to PDF_PARSE_TIMEOUT_SECONDS, and a commit racing that window
@@ -305,12 +312,24 @@ module Api
           # lock, where the claim is serialized against commit's own UPDATE.
           if !session.created? && !session.uploading?
             too_late = true
+          # An undeclared session becomes a document one HERE, at the point of
+          # no return — every rejection that could still refuse this upload has
+          # either passed already or is one of the two below, so the modality is
+          # only ever decided by content we actually keep. Deciding earlier let
+          # a mistyped file, or one over a ceiling, strand a session in a kind
+          # its owner never chose and could not leave. Under the row lock the
+          # read-check-write is safe: a concurrent audio claim either committed
+          # before our lock (we see it and 409) or blocks on the lock and then
+          # matches zero rows against `modality = 'pending'`, so it loses.
+          elsif !session.modality_pending? && !session.modality_document?
+            wrong_modality = true
           elsif attached_bytes_of(session, :document_files) + upload.size.to_i >
                 ScribeSession::MAX_DOCUMENT_BYTES
             rejection = "total documents exceed #{ScribeSession::MAX_DOCUMENT_BYTES} bytes"
           elsif session.document_pages + pages > ScribeSession::MAX_DOCUMENT_PAGES
             rejection = "total pages exceed #{ScribeSession::MAX_DOCUMENT_PAGES}"
           else
+            session.modality = "document" if session.modality_pending?
             session.document_files.attach(
               io: upload.tempfile.tap(&:rewind),
               filename: upload.original_filename,
@@ -326,6 +345,14 @@ module Api
           render_error(
             code: "validation_error",
             message: "documents cannot be uploaded from status #{session.status}",
+            status: :conflict
+          )
+          return
+        end
+        if wrong_modality
+          render_error(
+            code: "validation_error",
+            message: "this endpoint requires a document session (modality is #{session.modality})",
             status: :conflict
           )
           return
@@ -350,7 +377,22 @@ module Api
         # storage stream); document -> at least one uploaded document. This
         # guard sits BEFORE the atomic claim and OUTSIDE with_idempotency so an
         # empty commit is a plain, retryable 422 and never a cached response.
-        if session.modality_document?
+        # A still-undeclared session is definitionally empty — the modality is
+        # claimed at the exact point an upload is stored, so "pending" means
+        # nothing was ever stored. Say that, rather than borrowing the audio
+        # wording for a session that may well have been meant as a document.
+        # This arm is also what keeps `pending` out of the rest of the
+        # pipeline: commit is the only door to the orchestrator, commit_estimate
+        # and the metering function, and every one of them reads modality as
+        # "document or else audio". Nothing downstream ever sees pending.
+        if session.modality_pending?
+          render_error(
+            code: "validation_error",
+            message: "Nothing was uploaded to this session",
+            status: :unprocessable_entity
+          )
+          return
+        elsif session.modality_document?
           unless session.document_files.attached?
             render_error(
               code: "document_upload_failed",
@@ -531,12 +573,34 @@ module Api
       # versa), so callers can guard with `return if reject_wrong_modality(...)`.
       #
       # A session created without a declared modality starts "pending" (see
-      # SessionBuilder) and is determined by whichever upload surface reaches
-      # it first - the modality a client never declares is exactly the
-      # modality of the first request it actually sends.
+      # SessionBuilder) and is decided by whichever upload surface reaches it
+      # first — the modality a client never declares is exactly the modality of
+      # the first request it actually sends. An undecided session is therefore
+      # let through HERE and claimed later, by #claim_modality_or_reject, once
+      # the upload is known to be one we will actually store. Deciding at this
+      # point instead would let a refused upload — a .txt posted to /documents,
+      # a file over the size cap — permanently fix the modality of a session
+      # that never received a byte, so a typo would strand the session in a
+      # kind its owner never chose and cannot leave.
       def reject_wrong_modality(session, expected)
-        session.determine_modality!(expected)
+        return false if session.modality_pending?
         return false if session.modality == expected
+
+        render_error(
+          code: "validation_error",
+          message: "this endpoint requires a #{expected} session (modality is #{session.modality})",
+          status: :conflict
+        )
+        true
+      end
+
+      # Fixes an undeclared session's modality to this upload surface, and 409s
+      # if it cannot — which happens only when a concurrent first upload on the
+      # other surface won the race. Call this at the point of no return, once
+      # every rejection that could still refuse the upload has passed, so the
+      # modality is decided by content we actually keep.
+      def claim_modality_or_reject(session, expected)
+        return false if session.claim_modality(expected)
 
         render_error(
           code: "validation_error",

--- a/app/controllers/api/v2/scribe_sessions_controller.rb
+++ b/app/controllers/api/v2/scribe_sessions_controller.rb
@@ -312,15 +312,9 @@ module Api
           # lock, where the claim is serialized against commit's own UPDATE.
           if !session.created? && !session.uploading?
             too_late = true
-          # An undeclared session becomes a document one HERE, at the point of
-          # no return — every rejection that could still refuse this upload has
-          # either passed already or is one of the two below, so the modality is
-          # only ever decided by content we actually keep. Deciding earlier let
-          # a mistyped file, or one over a ceiling, strand a session in a kind
-          # its owner never chose and could not leave. Under the row lock the
-          # read-check-write is safe: a concurrent audio claim either committed
-          # before our lock (we see it and 409) or blocks on the lock and then
-          # matches zero rows against `modality = 'pending'`, so it loses.
+          # Claimed below, with the attach: the ceilings here must be able to
+          # refuse without deciding anything. Safe under the row lock — a racing
+          # audio claim either committed before it (we 409) or blocks and loses.
           elsif !session.modality_pending? && !session.modality_document?
             wrong_modality = true
           elsif attached_bytes_of(session, :document_files) + upload.size.to_i >
@@ -377,14 +371,9 @@ module Api
         # storage stream); document -> at least one uploaded document. This
         # guard sits BEFORE the atomic claim and OUTSIDE with_idempotency so an
         # empty commit is a plain, retryable 422 and never a cached response.
-        # A still-undeclared session is definitionally empty — the modality is
-        # claimed at the exact point an upload is stored, so "pending" means
-        # nothing was ever stored. Say that, rather than borrowing the audio
-        # wording for a session that may well have been meant as a document.
-        # This arm is also what keeps `pending` out of the rest of the
-        # pipeline: commit is the only door to the orchestrator, commit_estimate
-        # and the metering function, and every one of them reads modality as
-        # "document or else audio". Nothing downstream ever sees pending.
+        # Pending means nothing was ever stored. This arm is also what keeps
+        # pending out of the orchestrator, commit_estimate and metering, which
+        # all read modality as "document, else audio".
         if session.modality_pending?
           render_error(
             code: "validation_error",
@@ -572,16 +561,9 @@ module Api
       # match the upload surface (audio uploads to a document session or vice
       # versa), so callers can guard with `return if reject_wrong_modality(...)`.
       #
-      # A session created without a declared modality starts "pending" (see
-      # SessionBuilder) and is decided by whichever upload surface reaches it
-      # first — the modality a client never declares is exactly the modality of
-      # the first request it actually sends. An undecided session is therefore
-      # let through HERE and claimed later, by #claim_modality_or_reject, once
-      # the upload is known to be one we will actually store. Deciding at this
-      # point instead would let a refused upload — a .txt posted to /documents,
-      # a file over the size cap — permanently fix the modality of a session
-      # that never received a byte, so a typo would strand the session in a
-      # kind its owner never chose and cannot leave.
+      # A "pending" session is let through and claimed later, at the point the
+      # upload is actually stored — deciding here would let a refused upload fix
+      # the modality of a session that never received a byte.
       def reject_wrong_modality(session, expected)
         return false if session.modality_pending?
         return false if session.modality == expected
@@ -594,11 +576,8 @@ module Api
         true
       end
 
-      # Fixes an undeclared session's modality to this upload surface, and 409s
-      # if it cannot — which happens only when a concurrent first upload on the
-      # other surface won the race. Call this at the point of no return, once
-      # every rejection that could still refuse the upload has passed, so the
-      # modality is decided by content we actually keep.
+      # Claims an undeclared session for this surface at the point of no return.
+      # 409s only when a concurrent first upload won the other surface.
       def claim_modality_or_reject(session, expected)
         return false if session.claim_modality(expected)
 

--- a/app/controllers/api/v2/scribe_sessions_controller.rb
+++ b/app/controllers/api/v2/scribe_sessions_controller.rb
@@ -529,7 +529,13 @@ module Api
       # Renders a 409 and returns true when the session's modality does not
       # match the upload surface (audio uploads to a document session or vice
       # versa), so callers can guard with `return if reject_wrong_modality(...)`.
+      #
+      # A session created without a declared modality starts "pending" (see
+      # SessionBuilder) and is determined by whichever upload surface reaches
+      # it first - the modality a client never declares is exactly the
+      # modality of the first request it actually sends.
       def reject_wrong_modality(session, expected)
+        session.determine_modality!(expected)
         return false if session.modality == expected
 
         render_error(

--- a/app/models/scribe_session.rb
+++ b/app/models/scribe_session.rb
@@ -77,13 +77,24 @@ class ScribeSession < ApplicationRecord
   # What kind of source this session ingests: recorded audio (ASR) or an
   # uploaded lab report / document (vision OCR). Prefixed predicates
   # (modality_audio? / modality_document?) keep the bare audio-ish names free.
-  enum :modality, { audio: "audio", document: "document" }, prefix: :modality
+  # "pending" is a caller-omitted modality, awaiting the first upload to
+  # determine it (see #determine_modality!) - never set explicitly by a client.
+  enum :modality, { pending: "pending", audio: "audio", document: "document" }, prefix: :modality
 
   validates :status, presence: true
   validate :callback_url_is_safe
 
   def expired?
     expires_at.present? && expires_at < Time.current
+  end
+
+  # Locks in the session's modality from whichever upload surface reaches it
+  # first, when the caller didn't declare one at creation (SessionBuilder
+  # defaults an omitted modality to "pending"). A no-op once the modality is
+  # already audio/document, so later uploads of the same kind are free and a
+  # cross-modality upload still 409s via reject_wrong_modality.
+  def determine_modality!(kind)
+    update!(modality: kind) if modality_pending?
   end
 
   # The growing transcript DURING recording: the done segments' texts, in seq

--- a/app/models/scribe_session.rb
+++ b/app/models/scribe_session.rb
@@ -77,8 +77,8 @@ class ScribeSession < ApplicationRecord
   # What kind of source this session ingests: recorded audio (ASR) or an
   # uploaded lab report / document (vision OCR). Prefixed predicates
   # (modality_audio? / modality_document?) keep the bare audio-ish names free.
-  # "pending" is a caller-omitted modality, awaiting the first upload to
-  # determine it (see #determine_modality!) - never set explicitly by a client.
+  # "pending" is server-managed (SessionBuilder::CLIENT_MODALITIES): a caller
+  # who declares nothing gets it, and #claim_modality fixes it on first upload.
   enum :modality, { pending: "pending", audio: "audio", document: "document" }, prefix: :modality
 
   validates :status, presence: true
@@ -88,20 +88,12 @@ class ScribeSession < ApplicationRecord
     expires_at.present? && expires_at < Time.current
   end
 
-  # Locks in the session's modality from whichever upload surface reaches it
-  # first, when the caller didn't declare one at creation (SessionBuilder
-  # defaults an omitted modality to "pending"). Returns whether the session is
-  # NOW `kind` — false means somebody else claimed the other modality and the
-  # caller must 409.
+  # Fixes an undeclared session's modality to the surface of its first stored
+  # upload. Returns false when a concurrent first upload claimed the other one.
   #
-  # The claim is a conditional UPDATE, not a read-check-write. One session
-  # token can drive all four upload surfaces at once, so `if modality_pending?`
-  # followed by a save lets two first uploads both pass the check and the
-  # second overwrite the first: the session then holds BOTH audio and documents
-  # while claiming to be one of them, the orchestrator transcribes only the
-  # winner's kind, and any segments already uploaded were metered on arrival
-  # for a transcript nobody will ever read. `WHERE modality = 'pending'` makes
-  # exactly one claimant win; the reload tells the loser it lost.
+  # Conditional UPDATE, not a read-check-write: one token can drive all four
+  # upload surfaces at once, and two claimants both passing `modality_pending?`
+  # would leave a session holding audio AND documents.
   def claim_modality(kind)
     return true if modality == kind.to_s
     return false unless modality_pending?

--- a/app/models/scribe_session.rb
+++ b/app/models/scribe_session.rb
@@ -90,11 +90,26 @@ class ScribeSession < ApplicationRecord
 
   # Locks in the session's modality from whichever upload surface reaches it
   # first, when the caller didn't declare one at creation (SessionBuilder
-  # defaults an omitted modality to "pending"). A no-op once the modality is
-  # already audio/document, so later uploads of the same kind are free and a
-  # cross-modality upload still 409s via reject_wrong_modality.
-  def determine_modality!(kind)
-    update!(modality: kind) if modality_pending?
+  # defaults an omitted modality to "pending"). Returns whether the session is
+  # NOW `kind` — false means somebody else claimed the other modality and the
+  # caller must 409.
+  #
+  # The claim is a conditional UPDATE, not a read-check-write. One session
+  # token can drive all four upload surfaces at once, so `if modality_pending?`
+  # followed by a save lets two first uploads both pass the check and the
+  # second overwrite the first: the session then holds BOTH audio and documents
+  # while claiming to be one of them, the orchestrator transcribes only the
+  # winner's kind, and any segments already uploaded were metered on arrival
+  # for a transcript nobody will ever read. `WHERE modality = 'pending'` makes
+  # exactly one claimant win; the reload tells the loser it lost.
+  def claim_modality(kind)
+    return true if modality == kind.to_s
+    return false unless modality_pending?
+
+    self.class.where(id: id, modality: "pending")
+        .update_all(modality: kind.to_s, updated_at: Time.current)
+    reload
+    modality == kind.to_s
   end
 
   # The growing transcript DURING recording: the done segments' texts, in seq

--- a/app/services/scribe/session_builder.rb
+++ b/app/services/scribe/session_builder.rb
@@ -14,6 +14,9 @@ module Scribe
   # its transport demands.
   class SessionBuilder
     OUTPUT_TYPES = %w[transcript form note].freeze
+    # What a caller may declare. Omitted (or anything else) starts "pending" and
+    # is fixed by the first upload the server stores.
+    CLIENT_MODALITIES = %w[audio document].freeze
 
     Result = Struct.new(:session, :error, keyword_init: true) do
       def success?
@@ -63,7 +66,9 @@ module Scribe
         api_token: api_token,
         user: user,
         status: "created",
-        modality: modality.presence || "pending",
+        # "pending" is server-managed; a client asking for it explicitly is
+        # asking for nothing, so it means the same as omitting it.
+        modality: CLIENT_MODALITIES.include?(modality.to_s) ? modality.to_s : "pending",
         language: language_hint,
         mode: mode.presence || "consultation",
         callback_url: callback_url,

--- a/app/services/scribe/session_builder.rb
+++ b/app/services/scribe/session_builder.rb
@@ -63,7 +63,7 @@ module Scribe
         api_token: api_token,
         user: user,
         status: "created",
-        modality: modality.presence || "audio",
+        modality: modality.presence || "pending",
         language: language_hint,
         mode: mode.presence || "consultation",
         callback_url: callback_url,

--- a/docs/api/v2.md
+++ b/docs/api/v2.md
@@ -105,7 +105,7 @@ of:
 | Field           | Type   | Notes |
 |-----------------|--------|-------|
 | `outputs`       | array  | Required, non-empty. Each item: `type`, `page_id`, `template_ref`, `context`. |
-| `modality`      | string | `audio` (default, ASR) or `document` (lab-report OCR — upload via `/documents`). |
+| `modality`      | string | `audio` (ASR) or `document` (lab-report OCR — upload via `/documents`). **Optional.** Omit it and the session is created `pending`, then becomes whichever kind your first stored upload is: post to `/audio*` and it is an audio session, post to `/documents` and it is a document one. Declare it explicitly when you want the mismatched surface to 409 from the very first call. |
 | `language_hint` | string | Stored as the session `language` (e.g. `en`, `hi`, `ta`, `auto`). |
 | `mode`          | string | `consultation` (default) or `dictation`. |
 | `callback_url`  | string | If set, a webhook is delivered on completion. |
@@ -219,7 +219,8 @@ no result. Re-commit to retry it.
 - **200 OK** — `{ "id": <id>, "status": "uploading", "pages": <running total> }`.
 - **404 session_not_found** — unknown id (or another account's id).
 - **409 validation_error** — the session's modality is `audio` (and vice versa:
-  the audio endpoints 409 on a `document` session), or its status is past
+  the audio endpoints 409 on a `document` session). A `pending` session is
+  accepted and becomes a document session. Also returned when its status is past
   `uploading`.
 - **410 session_expired** — the session has passed `expires_at`.
 - **422 validation_error** — missing `document` field, unsupported content type,
@@ -411,7 +412,7 @@ Optional params (all backward compatible):
 
 | Field | Description |
 | --- | --- |
-| `modality` | `audio` or `document`. Fixed at creation. |
+| `modality` | `audio`, `document`, or `pending` for a session created without one that has not yet been uploaded to. Fixed by the first upload the server stores, and immutable after that. Treat it as an open set: a client that switches on it must tolerate `pending`. |
 | `transcript` | The extracted source text — OCR output for a `document` session, ASR output for an `audio` one — as `{ text, language }`, or `null` before it exists. **This is the top-level way to read OCR output**; it does not depend on having declared a `transcript` output. During an audio recording it carries the growing live transcript instead. |
 | `usage` | Per-session metering. `pages` is the quantity OCR is billed on; `audio_seconds` is the audio equivalent, and each is `0` for the other modality. `by_function` splits cost across `ocr` / `asr` / `structuring`. |
 

--- a/test/integration/api/v2/documents_test.rb
+++ b/test/integration/api/v2/documents_test.rb
@@ -254,6 +254,65 @@ module Api
         assert_response :conflict
       end
 
+      # An upload the server REFUSES stores nothing, so it must not get to say
+      # what kind of session this is. Deciding at the guard instead of at the
+      # point of no return meant one mistyped file stranded the session in a
+      # modality its owner never chose and could not leave.
+      test "a refused upload leaves an undeclared session undecided" do
+        post "/api/v2/scribe_sessions", params: { outputs: [ { type: "transcript" } ] }.to_json,
+             headers: @headers.merge("Content-Type" => "application/json")
+        session_id = JSON.parse(response.body)["id"]
+
+        file = Tempfile.new([ "notes", ".txt" ])
+        file.write("not a lab report")
+        file.rewind
+        post "/api/v2/scribe_sessions/#{session_id}/documents",
+             params: { document: Rack::Test::UploadedFile.new(file.path, "text/plain") }, headers: @headers
+        assert_response :unprocessable_entity
+        assert_equal 0, ScribeSession.find(session_id).document_files.count
+
+        assert_equal "pending", ScribeSession.find(session_id).modality,
+                     "a refused upload must not decide the session's modality"
+
+        # ...so the session is still free to become an audio one.
+        post "/api/v2/scribe_sessions/#{session_id}/audio",
+             params: { audio: audio_upload }, headers: @headers
+        assert_response :ok
+        assert_equal "audio", ScribeSession.find(session_id).modality
+      end
+
+      # The invariant the rest of the pipeline rests on: because the modality is
+      # claimed at the exact point an upload is stored, a still-pending session
+      # is definitionally empty and can never be committed — so the orchestrator,
+      # commit_estimate and the metering function (all of which read modality as
+      # "document, else audio") never see a pending session.
+      test "a session that was never uploaded to cannot be committed" do
+        post "/api/v2/scribe_sessions", params: { outputs: [ { type: "transcript" } ] }.to_json,
+             headers: @headers.merge("Content-Type" => "application/json")
+        session_id = JSON.parse(response.body)["id"]
+
+        post "/api/v2/scribe_sessions/#{session_id}/commit", headers: @headers
+
+        assert_response :unprocessable_entity
+        assert_match(/Nothing was uploaded/, JSON.parse(response.body).dig("error", "message"))
+        assert_equal "pending", ScribeSession.find(session_id).modality
+        assert_equal "created", ScribeSession.find(session_id).status
+        assert_equal 0, UsageEvent.where(scribe_session_id: session_id).count
+      end
+
+      # Same rule at the other rejection points: over the page cap, and over the
+      # per-file byte ceiling. Neither stores anything.
+      test "an upload rejected by a ceiling leaves an undeclared session undecided" do
+        post "/api/v2/scribe_sessions", params: { outputs: [ { type: "transcript" } ] }.to_json,
+             headers: @headers.merge("Content-Type" => "application/json")
+        session_id = JSON.parse(response.body)["id"]
+
+        post "/api/v2/scribe_sessions/#{session_id}/documents",
+             params: { document: pdf_upload(pages: ScribeSession::MAX_DOCUMENT_PAGES + 1) }, headers: @headers
+        assert_response :unprocessable_entity
+        assert_equal "pending", ScribeSession.find(session_id).modality
+      end
+
       test "committing a document session with no documents is a 422" do
         session_id = create_document_session
         post "/api/v2/scribe_sessions/#{session_id}/commit", headers: @headers

--- a/test/integration/api/v2/documents_test.rb
+++ b/test/integration/api/v2/documents_test.rb
@@ -228,11 +228,29 @@ module Api
              params: { audio: audio_upload }, headers: @headers
         assert_response :conflict
 
-        post "/api/v2/scribe_sessions", params: { outputs: [ { type: "transcript" } ] }.to_json,
+        post "/api/v2/scribe_sessions",
+             params: { modality: "audio", outputs: [ { type: "transcript" } ] }.to_json,
              headers: @headers.merge("Content-Type" => "application/json")
         audio_session = JSON.parse(response.body)["id"]
         post "/api/v2/scribe_sessions/#{audio_session}/documents",
              params: { document: image_upload }, headers: @headers
+        assert_response :conflict
+      end
+
+      test "a session with no declared modality is determined by whichever upload reaches it first" do
+        post "/api/v2/scribe_sessions", params: { outputs: [ { type: "transcript" } ] }.to_json,
+             headers: @headers.merge("Content-Type" => "application/json")
+        session_id = JSON.parse(response.body)["id"]
+        assert_equal "pending", ScribeSession.find(session_id).modality
+
+        post "/api/v2/scribe_sessions/#{session_id}/documents",
+             params: { document: image_upload }, headers: @headers
+        assert_response :ok
+        assert_equal "document", ScribeSession.find(session_id).modality
+
+        # Locked in now - a second, different-surface upload still 409s.
+        post "/api/v2/scribe_sessions/#{session_id}/audio",
+             params: { audio: audio_upload }, headers: @headers
         assert_response :conflict
       end
 

--- a/test/models/scribe_session_modality_test.rb
+++ b/test/models/scribe_session_modality_test.rb
@@ -1,0 +1,59 @@
+require "test_helper"
+
+# ScribeSession#claim_modality — the moment an undeclared session becomes an
+# audio one or a document one.
+class ScribeSessionModalityTest < ActiveSupport::TestCase
+  test "a pending session is claimed by the first caller" do
+    session = create(:scribe_session, modality: "pending")
+
+    assert session.claim_modality("document")
+    assert_equal "document", session.reload.modality
+  end
+
+  test "claiming the modality a session already has is a no-op that succeeds" do
+    session = create(:scribe_session, modality: "audio")
+
+    assert session.claim_modality("audio")
+    assert_equal "audio", session.reload.modality
+  end
+
+  test "claiming the other modality on a decided session fails without changing it" do
+    session = create(:scribe_session, modality: "audio")
+
+    assert_not session.claim_modality("document")
+    assert_equal "audio", session.reload.modality
+  end
+
+  # One session token can drive all four upload surfaces at once. With a
+  # read-check-write both claimants passed `modality_pending?` and the second
+  # overwrote the first, leaving a session holding BOTH kinds of content while
+  # claiming to be one of them — the orchestrator then transcribes only the
+  # winner's kind, and segments already uploaded were metered on arrival for a
+  # transcript nobody reads. Exactly one claimant may win.
+  test "two concurrent claimants: exactly one wins and the loser is told" do
+    session = create(:scribe_session, modality: "pending")
+    audio_side = ScribeSession.find(session.id)
+    document_side = ScribeSession.find(session.id)
+
+    first = audio_side.claim_modality("audio")
+    second = document_side.claim_modality("document")
+
+    assert first, "the first claimant should win"
+    assert_not second, "the second claimant must lose, not overwrite"
+    assert_equal "audio", session.reload.modality
+    # The loser's own object reflects reality, so the controller 409s with the
+    # modality the session actually has rather than the one it wanted.
+    assert_equal "audio", document_side.modality
+  end
+
+  test "the loser of a race sees the winning modality even in the other order" do
+    session = create(:scribe_session, modality: "pending")
+    audio_side = ScribeSession.find(session.id)
+    document_side = ScribeSession.find(session.id)
+
+    assert document_side.claim_modality("document")
+    assert_not audio_side.claim_modality("audio")
+    assert_equal "document", session.reload.modality
+    assert_equal "document", audio_side.modality
+  end
+end

--- a/test/services/scribe/session_builder_test.rb
+++ b/test/services/scribe/session_builder_test.rb
@@ -25,7 +25,7 @@ module Scribe
       assert result.success?
       assert_equal @account, result.session.account
       assert_equal "created", result.session.status
-      assert_equal "audio", result.session.modality
+      assert_equal "pending", result.session.modality
       assert_equal "consultation", result.session.mode
       assert_equal 3, result.session.scribe_outputs.count
       assert_equal %w[transcript form form], result.session.scribe_outputs.order(:id).map(&:output_type)

--- a/test/services/scribe/session_builder_test.rb
+++ b/test/services/scribe/session_builder_test.rb
@@ -31,6 +31,23 @@ module Scribe
       assert_equal %w[transcript form form], result.session.scribe_outputs.order(:id).map(&:output_type)
     end
 
+    test "a declared modality is kept" do
+      %w[audio document].each do |kind|
+        result = build(outputs: [ { type: "transcript" } ], modality: kind)
+        assert_equal kind, result.session.modality
+      end
+    end
+
+    # "pending" is server-managed: a client asking for it is asking for nothing,
+    # so it lands where omitting it does.
+    test "a client cannot declare pending, or any other unknown modality" do
+      [ "pending", "telepathy", "" ].each do |bad|
+        result = build(outputs: [ { type: "transcript" } ], modality: bad)
+        assert result.success?, bad
+        assert_equal "pending", result.session.modality, bad
+      end
+    end
+
     test "rejects an empty outputs array" do
       result = build(outputs: [])
 


### PR DESCRIPTION
Refactor modality handling in ScribeSession and SessionBuilder support "pending" state, ensuring correct modality determination on first upload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sessions without a specified modality remain pending until their first successful upload.
  * The first audio or document upload determines the session modality.
  * Once established, the modality cannot be changed; mismatched uploads are rejected.

* **Bug Fixes**
  * Unsuccessful or oversized uploads no longer lock the session’s modality.
  * Pending sessions cannot be committed before receiving an upload.

* **Documentation**
  * Updated API guidance to describe optional modality selection and pending sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->