### PR TITLE
Filter and label AI models by the function they can serve

### DIFF
--- a/app/dashboards/ai_model_dashboard.rb
+++ b/app/dashboards/ai_model_dashboard.rb
@@ -20,6 +20,10 @@ class AiModelDashboard < Administrate::BaseDashboard
     capabilities: Field::JsonObject.with_options(
       hint: 'JSON object of booleans, e.g. {"accepts_audio": true, "can_transcribe": true}'
     ),
+    # Which assignment functions this model can serve, derived from its
+    # capabilities — so the list answers "what can I use this for?" without
+    # opening each row and reading the JSON.
+    functions_label: Field::String.with_options(searchable: false, label: "Functions"),
     active: Field::Boolean,
     created_at: Field::DateTime,
     updated_at: Field::DateTime
@@ -34,6 +38,7 @@ class AiModelDashboard < Administrate::BaseDashboard
     display_name
     ai_provider
     api_model_id
+    functions_label
     active
   ].freeze
 
@@ -44,6 +49,7 @@ class AiModelDashboard < Administrate::BaseDashboard
     ai_provider
     api_model_id
     display_name
+    functions_label
     capabilities
     active
     created_at
@@ -64,8 +70,14 @@ class AiModelDashboard < Administrate::BaseDashboard
   # COLLECTION_FILTERS
   # a hash that defines filters that can be used while searching via the search
   # field of the dashboard.
+  # Typed into the search box as `asr:`, `ocr:`, `structuring:`. Configuring an
+  # assignment means finding the models that can serve one function, and the
+  # capabilities that decide it were only readable by opening each row.
   COLLECTION_FILTERS = {
-    active: ->(resources) { resources.where(active: true) }
+    active: ->(resources) { resources.where(active: true) },
+    asr: ->(resources) { resources.for_function("asr") },
+    structuring: ->(resources) { resources.for_function("structuring") },
+    ocr: ->(resources) { resources.for_function("ocr") }
   }.freeze
 
   # Overwrite this method to customize how ai models are displayed

--- a/app/models/ai_model.rb
+++ b/app/models/ai_model.rb
@@ -13,9 +13,47 @@ class AiModel < ApplicationRecord
   CAPABILITIES = %i[
     accepts_audio can_transcribe can_structure
     supports_json_schema supports_function_calling native_diarization
+    supports_vision supports_pdf
   ].freeze
+
+  # The MINIMUM capability set a model needs to serve each assignment function.
+  # Deliberately narrower than what Llm::DefaultConfigProvider stamps on a
+  # model: requiring structuring's full set would hide claude-3-5-haiku, which
+  # structures without supports_json_schema.
+  FUNCTION_CAPABILITIES = {
+    "asr" => %w[accepts_audio can_transcribe],
+    "structuring" => %w[can_structure],
+    "ocr" => %w[supports_vision]
+  }.freeze
+
+  # Models that can serve `function`. jsonb containment, so it is one indexable
+  # predicate rather than a scan in Ruby.
+  scope :for_function, ->(function) {
+    required = FUNCTION_CAPABILITIES[function.to_s]
+    next none if required.blank?
+
+    required.reduce(all) do |scope, capability|
+      scope.where("capabilities @> ?", { capability => true }.to_json)
+    end
+  }
 
   def capability?(name)
     !!capabilities[name.to_s] || !!capabilities[name.to_sym]
+  end
+
+  # The functions this model can be assigned to, e.g. ["structuring", "ocr"].
+  def functions
+    FUNCTION_CAPABILITIES.keys.select { |function| serves?(function) }
+  end
+
+  # Display form for the admin list. "—" rather than an empty cell, so a model
+  # nothing can use is visibly that rather than looking like a rendering gap.
+  def functions_label
+    functions.presence&.join(", ") || "—"
+  end
+
+  def serves?(function)
+    Array(FUNCTION_CAPABILITIES[function.to_s]).present? &&
+      FUNCTION_CAPABILITIES[function.to_s].all? { |capability| capability?(capability) }
   end
 end

--- a/test/integration/admin/ai_config_test.rb
+++ b/test/integration/admin/ai_config_test.rb
@@ -38,6 +38,37 @@ module Admin
       assert_response :success
     end
 
+    # Configuring an assignment means finding the models that can serve one
+    # function. Typed into the search box as `ocr:` / `asr:` / `structuring:`.
+    test "ai_models index filters by the function a model can serve" do
+      asr = create(:ai_model, ai_provider: @provider, display_name: "Whispery",
+                              capabilities: { "accepts_audio" => true, "can_transcribe" => true })
+      vision = create(:ai_model, ai_provider: @provider, display_name: "Seer",
+                                 capabilities: { "supports_vision" => true })
+
+      get admin_ai_models_path(search: "ocr:")
+      assert_response :success
+      assert_includes response.body, "Seer"
+      assert_not_includes response.body, "Whispery"
+
+      get admin_ai_models_path(search: "asr:")
+      assert_response :success
+      assert_includes response.body, "Whispery"
+      assert_not_includes response.body, "Seer"
+    end
+
+    test "ai_models index names the functions each model can serve, readably" do
+      create(:ai_model, ai_provider: @provider, display_name: "Dual",
+                        capabilities: { "can_structure" => true, "supports_vision" => true })
+
+      get admin_ai_models_path
+      assert_response :success
+      # The cell itself, not just the words appearing somewhere on the page —
+      # and not a raw Ruby array, which is what Field::String renders for one.
+      assert_includes response.body.gsub(/\s+/, " "), "structuring, ocr"
+      assert_not_includes response.body, "[&quot;structuring&quot;"
+    end
+
     test "model_assignments index renders" do
       get admin_model_assignments_path
       assert_response :success

--- a/test/models/ai_model_test.rb
+++ b/test/models/ai_model_test.rb
@@ -1,43 +1,57 @@
 require "test_helper"
 
-# `capabilities` is the same shape of jsonb column as ModelAssignment#options
-# and is edited through the same admin JSON textarea, so it gets the same
-# coercion + validation. Without it a String slips through, `capability?`
-# silently returns garbage (String#[]), and Llm::ConfigResolver#symbolize crashes.
 class AiModelTest < ActiveSupport::TestCase
-  test "capabilities accepts a Hash unchanged" do
-    model = create(:ai_model, capabilities: { "accepts_audio" => true, "can_transcribe" => true })
-    assert_equal({ "accepts_audio" => true, "can_transcribe" => true }, model.reload.capabilities)
-    assert model.capability?(:can_transcribe)
-    assert_not model.capability?(:can_structure)
+  setup { @provider = create(:ai_provider) }
+
+  def model(capabilities)
+    create(:ai_model, ai_provider: @provider, capabilities: capabilities)
   end
 
-  test "capabilities coerces a JSON object string into a Hash" do
-    model = create(:ai_model, capabilities: '{"accepts_audio": true, "can_transcribe": true}')
-    model.reload
-    assert_equal({ "accepts_audio" => true, "can_transcribe" => true }, model.capabilities)
-    assert_equal "object", jsonb_typeof(model)
-    assert model.capability?(:can_transcribe)
+  test "for_function finds only models carrying every required capability" do
+    asr = model("accepts_audio" => true, "can_transcribe" => true)
+    partial = model("accepts_audio" => true)
+    vision = model("supports_vision" => true, "supports_pdf" => true)
+    structuring = model("can_structure" => true)
+
+    assert_equal [ asr ], AiModel.for_function("asr").to_a
+    assert_equal [ vision ], AiModel.for_function("ocr").to_a
+    assert_equal [ structuring ], AiModel.for_function("structuring").to_a
+    assert_not_includes AiModel.for_function("asr"), partial
   end
 
-  test "capabilities treats a blank string or nil as an empty object" do
-    assert_equal({}, create(:ai_model, capabilities: "").reload.capabilities)
-    assert_equal({}, create(:ai_model, capabilities: nil).reload.capabilities)
+  test "for_function accepts a symbol and returns nothing for an unknown function" do
+    model("can_structure" => true)
+
+    assert_equal 1, AiModel.for_function(:structuring).count
+    assert_empty AiModel.for_function("telepathy")
   end
 
-  test "capabilities rejects JSON that is not an object" do
-    [ '"{}"', "[true]", "1", "nope", '{"accepts_audio" => true}' ].each do |bad|
-      model = build(:ai_model, capabilities: bad)
-      assert_not model.valid?, "expected #{bad.inspect} to be invalid"
-      assert_includes model.errors[:capabilities], "must be a JSON object", "for #{bad.inspect}"
-    end
+  # A model can serve more than one function; the list column shows all of them.
+  test "functions lists every function a model can serve" do
+    both = model("can_structure" => true, "supports_vision" => true)
+
+    assert_equal %w[structuring ocr], both.functions
+    assert both.serves?("ocr")
+    assert_not both.serves?("asr")
   end
 
-  private
+  test "a model with no capabilities serves nothing" do
+    assert_empty model({}).functions
+  end
 
-  def jsonb_typeof(record)
-    AiModel.connection.select_value(
-      "SELECT jsonb_typeof(capabilities) FROM ai_models WHERE id = #{record.id}"
-    )
+  # The structuring requirement is deliberately just can_structure: the seeded
+  # claude-3-5-haiku structures without supports_json_schema and must stay
+  # discoverable.
+  test "structuring does not require the full stamped capability set" do
+    haiku_like = model("can_structure" => true, "supports_function_calling" => true)
+
+    assert_includes AiModel.for_function("structuring"), haiku_like
+  end
+
+  test "the OCR models the catalog provisions are discoverable as OCR" do
+    OpenrouterCatalog.provision!
+
+    slugs = AiModel.for_function("ocr").pluck(:api_model_id)
+    OpenrouterCatalog::OCR_MODELS.each_key { |slug| assert_includes slugs, slug }
   end
 end

--- a/test/models/ai_model_test.rb
+++ b/test/models/ai_model_test.rb
@@ -1,17 +1,50 @@
 require "test_helper"
 
+# `capabilities` is the same shape of jsonb column as ModelAssignment#options
+# and is edited through the same admin JSON textarea, so it gets the same
+# coercion + validation. Without it a String slips through, `capability?`
+# silently returns garbage (String#[]), and Llm::ConfigResolver#symbolize crashes.
 class AiModelTest < ActiveSupport::TestCase
-  setup { @provider = create(:ai_provider) }
+  test "capabilities accepts a Hash unchanged" do
+    model = create(:ai_model, capabilities: { "accepts_audio" => true, "can_transcribe" => true })
+    assert_equal({ "accepts_audio" => true, "can_transcribe" => true }, model.reload.capabilities)
+    assert model.capability?(:can_transcribe)
+    assert_not model.capability?(:can_structure)
+  end
 
-  def model(capabilities)
-    create(:ai_model, ai_provider: @provider, capabilities: capabilities)
+  test "capabilities coerces a JSON object string into a Hash" do
+    model = create(:ai_model, capabilities: '{"accepts_audio": true, "can_transcribe": true}')
+    model.reload
+    assert_equal({ "accepts_audio" => true, "can_transcribe" => true }, model.capabilities)
+    assert_equal "object", jsonb_typeof(model)
+    assert model.capability?(:can_transcribe)
+  end
+
+  test "capabilities treats a blank string or nil as an empty object" do
+    assert_equal({}, create(:ai_model, capabilities: "").reload.capabilities)
+    assert_equal({}, create(:ai_model, capabilities: nil).reload.capabilities)
+  end
+
+  test "capabilities rejects JSON that is not an object" do
+    [ '"{}"', "[true]", "1", "nope", '{"accepts_audio" => true}' ].each do |bad|
+      model = build(:ai_model, capabilities: bad)
+      assert_not model.valid?, "expected #{bad.inspect} to be invalid"
+      assert_includes model.errors[:capabilities], "must be a JSON object", "for #{bad.inspect}"
+    end
+  end
+
+
+  # --- function discovery -----------------------------------------------
+
+  def discovery_model(capabilities)
+    create(:ai_model, ai_provider: @discovery_provider ||= create(:ai_provider), capabilities: capabilities)
   end
 
   test "for_function finds only models carrying every required capability" do
-    asr = model("accepts_audio" => true, "can_transcribe" => true)
-    partial = model("accepts_audio" => true)
-    vision = model("supports_vision" => true, "supports_pdf" => true)
-    structuring = model("can_structure" => true)
+    asr = discovery_model("accepts_audio" => true, "can_transcribe" => true)
+    partial = discovery_model("accepts_audio" => true)
+    vision = discovery_model("supports_vision" => true, "supports_pdf" => true)
+    structuring = discovery_model("can_structure" => true)
 
     assert_equal [ asr ], AiModel.for_function("asr").to_a
     assert_equal [ vision ], AiModel.for_function("ocr").to_a
@@ -20,7 +53,7 @@ class AiModelTest < ActiveSupport::TestCase
   end
 
   test "for_function accepts a symbol and returns nothing for an unknown function" do
-    model("can_structure" => true)
+    discovery_model("can_structure" => true)
 
     assert_equal 1, AiModel.for_function(:structuring).count
     assert_empty AiModel.for_function("telepathy")
@@ -28,7 +61,7 @@ class AiModelTest < ActiveSupport::TestCase
 
   # A model can serve more than one function; the list column shows all of them.
   test "functions lists every function a model can serve" do
-    both = model("can_structure" => true, "supports_vision" => true)
+    both = discovery_model("can_structure" => true, "supports_vision" => true)
 
     assert_equal %w[structuring ocr], both.functions
     assert both.serves?("ocr")
@@ -36,14 +69,14 @@ class AiModelTest < ActiveSupport::TestCase
   end
 
   test "a model with no capabilities serves nothing" do
-    assert_empty model({}).functions
+    assert_empty discovery_model({}).functions
   end
 
   # The structuring requirement is deliberately just can_structure: the seeded
   # claude-3-5-haiku structures without supports_json_schema and must stay
   # discoverable.
   test "structuring does not require the full stamped capability set" do
-    haiku_like = model("can_structure" => true, "supports_function_calling" => true)
+    haiku_like = discovery_model("can_structure" => true, "supports_function_calling" => true)
 
     assert_includes AiModel.for_function("structuring"), haiku_like
   end
@@ -53,5 +86,13 @@ class AiModelTest < ActiveSupport::TestCase
 
     slugs = AiModel.for_function("ocr").pluck(:api_model_id)
     OpenrouterCatalog::OCR_MODELS.each_key { |slug| assert_includes slugs, slug }
+  end
+
+  private
+
+  def jsonb_typeof(record)
+    AiModel.connection.select_value(
+      "SELECT jsonb_typeof(capabilities) FROM ai_models WHERE id = #{record.id}"
+    )
   end
 end


### PR DESCRIPTION
Configuring a model assignment meant scanning ~30 models whose only
distinguishing data — the capabilities JSON — was invisible on the index and
readable only by opening each row one at a time. Columns were
name/provider/id/active; the only filter was `active`.

**Now:** the list shows which functions each model can serve, and the search box
takes `asr:`, `structuring:` and `ocr:`.

| | before | after |
| --- | --- | --- |
| columns | name, provider, id, active | + **Functions** (`structuring, ocr`) |
| filters | `active:` | + `asr:` `structuring:` `ocr:` |

`AiModel::FUNCTION_CAPABILITIES` is the minimum capability set per function,
with a `for_function` scope using jsonb containment. It is deliberately
*narrower* than what `Llm::DefaultConfigProvider` stamps on a model — requiring
structuring's full stamped set would hide the seeded `claude-3-5-haiku`, which
structures without `supports_json_schema`. That distinction is commented so the
two don't get "unified" later.

Also fixes `AiModel::CAPABILITIES`, which never gained `supports_vision` /
`supports_pdf` when the OCR modality landed.

Verified through the real admin controller, not just the scope: the filter tests
drive `admin_ai_models_path(search: "ocr:")` and assert the right rows appear
and the wrong ones don't. The label test asserts the actual cell content — the
first cut rendered the raw Ruby array `["structuring", "ocr"]`, which the test
now pins against.

## Not included

The `ai_model` dropdown on the assignment form still lists every model
regardless of the chosen function. Constraining it needs JS in Administrate, so
it is worth its own change — the filters above make finding the right model
possible in the meantime.

## Test plan

- [x] `bin/rails test` — 627 runs, 2279 assertions, 0 failures
- [x] `bin/rubocop` — clean (290 files)
- [x] `bin/brakeman` — 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
