### PR TITLE
Add GPT-5.6 Luna and Gemini 3.6 Flash for OCR and structuring

### DIFF
--- a/db/migrate/20260817140000_provision_luna_and_gemini_models.rb
+++ b/db/migrate/20260817140000_provision_luna_and_gemini_models.rb
@@ -1,0 +1,16 @@
+# Adds GPT-5.6 Luna (OpenAI direct AND via OpenRouter) and Gemini 3.6 Flash
+# (OpenRouter) as selectable OCR + structuring models. Both handle image and
+# PDF input and both clear OcrStage's 32k output cap.
+#
+# Selectable only: no assignment is changed, so nothing switches model until an
+# operator picks one.
+class ProvisionLunaAndGeminiModels < ActiveRecord::Migration[8.1]
+  def up
+    OpenrouterCatalog.provision!
+    OpenaiCatalog.provision!
+  end
+
+  def down
+    # Configuration rows; leave them in place.
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_17_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_17_140000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -279,6 +279,10 @@ end
 # placeholder so the row shows in the UI.
 openrouter_provider = OpenrouterCatalog.provision!
 
+# OpenAI-direct models beyond the ones created inline below, from
+# lib/openai_catalog.rb (shared with the ProvisionLunaAndGeminiModels migration).
+OpenaiCatalog.provision!
+
 anthropic_provider = AiProvider.find_or_create_by!(name: "Anthropic") do |p|
   p.kind = "anthropic"
   p.base_url = "https://api.anthropic.com"

--- a/lib/openai_catalog.rb
+++ b/lib/openai_catalog.rb
@@ -1,0 +1,52 @@
+# OpenAI-direct models beyond the ones db/seeds.rb creates inline, and their
+# list prices. Shared by seeds and the provisioning data migration so the two
+# cannot drift — the same reason OpenrouterCatalog exists.
+#
+# Direct is a different row from the OpenRouter one for the same model: a
+# different provider, key, base_url and price table entry. Having both lets an
+# operator move a function between them without editing anything else, and the
+# adapter already sends the right output-budget parameter for each host
+# (max_completion_tokens for api.openai.com, max_tokens elsewhere).
+module OpenaiCatalog
+  PROVIDER_NAME = "OpenAI".freeze
+
+  # api_model_id => { display_name:, capabilities:, input_per_million:, output_per_million: }
+  MODELS = {
+    "gpt-5.6-luna" => {
+      display_name: "GPT-5.6 Luna",
+      capabilities: {
+        "can_structure" => true, "supports_json_schema" => true,
+        "supports_function_calling" => true,
+        "supports_vision" => true, "supports_pdf" => true,
+        "max_output_tokens" => 128_000
+      },
+      # OpenRouter lists this model at the same figures, which is its pass-through
+      # of OpenAI's list price. Correct it in the admin if OpenAI's direct rate
+      # differs — the price is a row, not code.
+      input_per_million: 0.10,
+      output_per_million: 0.60
+    }
+  }.freeze
+
+  # Idempotent: creates only what is missing, never overwrites an operator's
+  # rows. Returns the provider, or nil when it does not exist yet.
+  def self.provision!(now: Time.current)
+    provider = AiProvider.find_by(name: PROVIDER_NAME)
+    return nil unless provider
+
+    MODELS.each do |api_model_id, attrs|
+      AiModel.find_or_create_by!(ai_provider: provider, api_model_id: api_model_id) do |m|
+        m.display_name = attrs[:display_name]
+        m.capabilities = attrs[:capabilities]
+      end
+      ModelPrice.find_or_create_by!(provider: PROVIDER_NAME, model: api_model_id) do |price|
+        price.input_per_million = attrs[:input_per_million]
+        price.output_per_million = attrs[:output_per_million]
+        price.currency = "USD"
+        price.effective_at = now
+      end
+    end
+
+    provider
+  end
+end

--- a/lib/openrouter_catalog.rb
+++ b/lib/openrouter_catalog.rb
@@ -47,7 +47,11 @@ module OpenrouterCatalog
     "google/gemini-3.1-flash-lite" => { display_name: "Gemini 3.1 Flash Lite (OpenRouter)", input_per_million: 0.25, output_per_million: 1.50 },
     "google/gemini-3.7-flash" => { display_name: "Gemini 3.7 Flash (OpenRouter)", input_per_million: 0.375, output_per_million: 1.875 },
     "nvidia/nemotron-3-super-120b-a12b" => { display_name: "Nemotron 3 Super 120B (OpenRouter)", input_per_million: 0.085, output_per_million: 0.40 },
-    "nvidia/nemotron-3.5-lightning" => { display_name: "Nemotron 3.5 Lightning (OpenRouter)", input_per_million: 0.10, output_per_million: 0.25 }
+    "nvidia/nemotron-3.5-lightning" => { display_name: "Nemotron 3.5 Lightning (OpenRouter)", input_per_million: 0.10, output_per_million: 0.25 },
+    # Also OCR models (see OCR_MODELS): one row serves both functions, and
+    # provision! merges the vision capabilities in after this loop creates it.
+    "openai/gpt-5.6-luna" => { display_name: "GPT-5.6 Luna (OpenRouter)", input_per_million: 0.10, output_per_million: 0.60 },
+    "google/gemini-3.6-flash" => { display_name: "Gemini 3.6 Flash (OpenRouter)", input_per_million: 0.75, output_per_million: 3.75 }
   }.freeze
 
   # Vision models for the document (OCR) modality.
@@ -100,6 +104,15 @@ module OpenrouterCatalog
     "anthropic/claude-haiku-4.5" => {
       display_name: "Claude Haiku 4.5 (OpenRouter)",
       input_per_million: 1.00, output_per_million: 5.00, max_output_tokens: 64_000
+    },
+    # Also in STRUCTURING_MODELS — one AiModel row serves both functions.
+    "openai/gpt-5.6-luna" => {
+      display_name: "GPT-5.6 Luna (OpenRouter)",
+      input_per_million: 0.10, output_per_million: 0.60, max_output_tokens: 128_000
+    },
+    "google/gemini-3.6-flash" => {
+      display_name: "Gemini 3.6 Flash (OpenRouter)",
+      input_per_million: 0.75, output_per_million: 3.75, max_output_tokens: 65_536
     }
   }.freeze
 

--- a/test/lib/openai_catalog_test.rb
+++ b/test/lib/openai_catalog_test.rb
@@ -1,0 +1,50 @@
+require "test_helper"
+
+class OpenaiCatalogTest < ActiveSupport::TestCase
+  test "provision! is a no-op when the OpenAI provider does not exist" do
+    assert_no_difference([ "AiModel.count", "ModelPrice.count" ]) do
+      assert_nil OpenaiCatalog.provision!
+    end
+  end
+
+  test "provision! creates each model with its capabilities and a token price" do
+    provider = create(:ai_provider, name: "OpenAI", base_url: "https://api.openai.com/")
+    OpenaiCatalog.provision!
+
+    OpenaiCatalog::MODELS.each do |slug, attrs|
+      model = AiModel.find_by!(ai_provider: provider, api_model_id: slug)
+      assert_equal attrs[:display_name], model.display_name
+      assert_equal attrs[:capabilities], model.capabilities
+
+      price = ModelPrice.current.find_by(provider: "OpenAI", model: slug)
+      assert price, "token price for #{slug}"
+      assert_equal attrs[:input_per_million], price.input_per_million.to_f
+    end
+  end
+
+  test "the models it provisions serve both OCR and structuring" do
+    create(:ai_provider, name: "OpenAI", base_url: "https://api.openai.com/")
+    OpenaiCatalog.provision!
+
+    OpenaiCatalog::MODELS.each_key do |slug|
+      model = AiModel.find_by!(api_model_id: slug)
+      assert model.capability?(:supports_vision), "#{slug} must be usable for OCR"
+      assert model.capability?(:supports_pdf), slug
+      assert model.capability?(:can_structure), "#{slug} must be usable for structuring"
+      # OcrStage asks for up to MAX_MAX_TOKENS; a ceiling below that would make
+      # the adapter clamp a long report for no reason.
+      assert_operator model.capabilities["max_output_tokens"], :>=,
+                      Scribe::OcrStage::MAX_MAX_TOKENS, slug
+    end
+  end
+
+  test "provision! is idempotent and never overwrites an operator's rows" do
+    create(:ai_provider, name: "OpenAI", base_url: "https://api.openai.com/")
+    OpenaiCatalog.provision!
+    slug = OpenaiCatalog::MODELS.keys.first
+    AiModel.find_by!(api_model_id: slug).update!(display_name: "custom")
+
+    assert_no_difference([ "AiModel.count", "ModelPrice.count" ]) { OpenaiCatalog.provision! }
+    assert_equal "custom", AiModel.find_by!(api_model_id: slug).display_name
+  end
+end

--- a/test/lib/openrouter_catalog_test.rb
+++ b/test/lib/openrouter_catalog_test.rb
@@ -62,6 +62,26 @@ class OpenrouterCatalogTest < ActiveSupport::TestCase
     end
   end
 
+  # A model listed in both STRUCTURING_MODELS and OCR_MODELS is ONE AiModel row.
+  # The structuring loop creates it first, so the vision keys have to be merged
+  # in afterwards or the row silently serves only structuring.
+  test "a model in both catalogs ends up serving both functions" do
+    provider = OpenrouterCatalog.provision!
+    dual = OpenrouterCatalog::OCR_MODELS.keys & OpenrouterCatalog::STRUCTURING_MODELS.keys
+    assert dual.any?, "expected at least one model listed under both functions"
+
+    dual.each do |slug|
+      model = AiModel.find_by!(ai_provider: provider, api_model_id: slug)
+      assert model.capability?(:can_structure), slug
+      assert model.capability?(:supports_vision), slug
+      assert model.capability?(:supports_pdf), slug
+      assert_equal OpenrouterCatalog::OCR_MODELS[slug][:max_output_tokens],
+                   model.capabilities["max_output_tokens"], slug
+      # One price row, not one per catalog.
+      assert_equal 1, ModelPrice.where(provider: "OpenRouter", model: slug).count, slug
+    end
+  end
+
   test "assign_default_ocr! points the System default at the chosen model with a different-vendor fallback" do
     OpenrouterCatalog.provision!
     assignment = OpenrouterCatalog.assign_default_ocr!


### PR DESCRIPTION
Selectable options only — no assignment changes, so nothing switches model
until you pick one in the admin.

| model | provider | in / out per M | max output |
| --- | --- | --- | --- |
| `gpt-5.6-luna` | OpenAI direct | $0.10 / $0.60 | 128,000 |
| `openai/gpt-5.6-luna` | OpenRouter | $0.10 / $0.60 | 128,000 |
| `google/gemini-3.6-flash` | OpenRouter | $0.75 / $3.75 | 65,536 |

All three verified against OpenRouter's **live** catalogue rather than from
memory: each accepts image *and* file input (the adapter sends a PDF as a
`file` part, a photo as `image_url`), accepts the output-budget parameter, and
clears `OcrStage`'s 32k cap so a full 20-page document is deliverable. Each is
capability-stamped for both OCR and structuring.

**Luna direct and Luna via OpenRouter are deliberately separate rows** — a
different provider, key, base_url and price entry — so a function can be moved
between them without editing anything else. The adapter already sends the right
budget parameter for each host (`max_completion_tokens` for `api.openai.com`,
`max_tokens` elsewhere).

Both OpenRouter models are listed under `STRUCTURING_MODELS` **and**
`OCR_MODELS`, which is a single `AiModel` row: the structuring loop creates it
and the OCR loop merges the vision capabilities in. There's a test pinning that,
because a regression would leave the row silently serving only one function —
the same trap that would have shipped `gemini-3.7-flash` without an output
ceiling last time.

`lib/openai_catalog.rb` is new, mirroring `OpenrouterCatalog` so `db/seeds.rb`
and the migration share one definition instead of drifting.

**One assumption to check:** OpenAI-direct pricing is OpenRouter's pass-through
of the list price ($0.10/$0.60). If OpenAI's direct rate differs, correct it in
the admin — the price is a row, not code.

## Test plan

- [x] `bin/rails test` — 628 runs, 2336 assertions, 0 failures
- [x] `bin/rubocop` — clean (293 files)
- [x] `bin/brakeman` — 0 warnings
- [x] Migration runs clean on a dev DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)
