### PR TITLE
Add ocr_mode: extract_and_structure — one vision call, no transcript

### DIFF
--- a/app/dashboards/model_assignment_dashboard.rb
+++ b/app/dashboards/model_assignment_dashboard.rb
@@ -30,7 +30,10 @@ class ModelAssignmentDashboard < Administrate::BaseDashboard
     # NEVER Field::Text here — it persists the textarea as a JSON *string* and
     # takes down every resolver call (2026-08-16 incident).
     options: Field::JsonObject.with_options(
-      hint: 'JSON object of resolver options, e.g. {} or {"asr_mode": "translate"}'
+      hint: 'JSON object of resolver options, e.g. {} or {"asr_mode": "translate"}. ' \
+            'On an OCR assignment, {"ocr_mode": "extract_and_structure"} fills the form in ONE ' \
+            "vision call and emits no transcript text (~3x cheaper; applies only to a " \
+            "single-output session of 2 pages or fewer on a structuring-capable model)."
     ),
     created_at: Field::DateTime,
     updated_at: Field::DateTime

--- a/app/services/llm/adapter.rb
+++ b/app/services/llm/adapter.rb
@@ -14,6 +14,8 @@ module Llm
       raise NotImplementedError, "#{self.class} must implement #transcribe"
     end
 
+    # documents: structure straight from the source file rather than from
+    # already-extracted text. Adapters that cannot see may ignore it.
     def structure(*)
       raise NotImplementedError, "#{self.class} must implement #structure"
     end

--- a/app/services/llm/adapters/anthropic.rb
+++ b/app/services/llm/adapters/anthropic.rb
@@ -28,11 +28,21 @@ module Llm
         raise Llm::BadResponse, "Anthropic does not support audio transcription"
       end
 
-      def structure(messages:, schema:, **_opts)
+      # `documents` structures straight from the source file instead of from
+      # already-extracted text (Llm::Config#ocr_mode :extract_and_structure).
+      def structure(messages:, schema:, documents: nil, max_tokens: nil, **_opts)
         started = monotonic
 
-        response = client.post("/v1/messages", request_body(messages, schema))
+        response = client.post("/v1/messages", request_body(messages, schema, documents, max_tokens))
         resp = response.body
+        # With documents attached this is the same completeness rule the OCR
+        # path uses, so a truncation raises INSIDE the attempt (where Caller can
+        # spend the fallback) and a refusal becomes Llm::Refused. tool_use is a
+        # valid terminal stop reason for a forced-tool call.
+        if documents.present? && resp["stop_reason"].to_s != "tool_use"
+          guard_ocr_completion!(resp["stop_reason"], usage: usage_from(resp["usage"]),
+                                                     latency_ms: elapsed_ms(started))
+        end
         structured = extract_tool_input(resp)
 
         Llm::Result.new(
@@ -122,12 +132,12 @@ module Llm
         text
       end
 
-      def request_body(messages, schema)
+      def request_body(messages, schema, documents = nil, max_tokens = nil)
         {
           model: config.api_model_id,
-          max_tokens: config.options[:max_tokens] || DEFAULT_MAX_TOKENS,
+          max_tokens: clamp_ocr_budget(max_tokens) || config.options[:max_tokens] || DEFAULT_MAX_TOKENS,
           system: system_prompt(messages),
-          messages: chat_messages(messages),
+          messages: with_documents(chat_messages(messages), documents),
           tools: [
             {
               name: TOOL_NAME,
@@ -144,6 +154,22 @@ module Llm
       def system_prompt(messages)
         msg = messages.find { |m| role_of(m).to_s == "system" }
         msg && content_of(msg)
+      end
+
+      # Prepends the source documents to the first user turn, so the model reads
+      # the file and fills the schema in one call.
+      def with_documents(messages, documents)
+        return messages if documents.blank?
+
+        blocks = documents.map { |doc| document_block(doc) }
+        first_user = messages.index { |m| m[:role].to_s == "user" }
+        return messages unless first_user
+
+        messages.each_with_index.map do |message, i|
+          next message unless i == first_user
+
+          { role: "user", content: blocks + [ { type: "text", text: message[:content].to_s } ] }
+        end
       end
 
       def chat_messages(messages)

--- a/app/services/llm/adapters/openai_compatible.rb
+++ b/app/services/llm/adapters/openai_compatible.rb
@@ -34,10 +34,13 @@ module Llm
         raise map_transport_error(e)
       end
 
-      def structure(messages:, schema:, **_opts)
+      # `documents` structures straight from the source file instead of from
+      # already-extracted text (Llm::Config#ocr_mode :extract_and_structure).
+      def structure(messages:, schema:, documents: nil, max_tokens: nil, **_opts)
         started = monotonic
-        params = { model: config.api_model_id, messages: messages }
+        params = { model: config.api_model_id, messages: with_documents(messages, documents) }
         params[:response_format] = json_schema_format(schema) if config.capability?(:supports_json_schema)
+        params[output_budget_param] = clamp_ocr_budget(max_tokens) if max_tokens
 
         response = client.chat(parameters: params)
         choice = response.dig("choices", 0) || {}
@@ -46,8 +49,13 @@ module Llm
 
         # A 200 that stopped early (e.g. "length") carries truncated content;
         # don't trust it. Surface as a transient BadResponse so Caller falls back
-        # — mirrors the Anthropic adapter's missing-tool-block handling.
-        if finish_reason && !%w[stop].include?(finish_reason.to_s)
+        # — mirrors the Anthropic adapter's missing-tool-block handling. With
+        # documents attached this is the same guard the OCR path uses, so a
+        # refusal is Llm::Refused and is not retried on the fallback.
+        if documents.present?
+          guard_ocr_completion!(finish_reason, usage: usage_from(response["usage"]),
+                                               latency_ms: elapsed_ms(started))
+        elsif finish_reason && !%w[stop].include?(finish_reason.to_s)
           raise Llm::BadResponse, "model did not complete (finish_reason=#{finish_reason})"
         end
 
@@ -133,6 +141,23 @@ module Llm
           nil
         end
         host == OPENAI_HOST ? :max_completion_tokens : :max_tokens
+      end
+
+      # Prepends the source documents to the first user turn, so the model reads
+      # the file and fills the schema in one call.
+      def with_documents(messages, documents)
+        return messages if documents.blank?
+
+        parts = documents.map { |doc| document_part(doc) }
+        first_user = messages.index { |m| (m[:role] || m["role"]).to_s == "user" }
+        return messages unless first_user
+
+        messages.each_with_index.map do |message, i|
+          next message unless i == first_user
+
+          text = message[:content] || message["content"]
+          { role: "user", content: parts + [ { type: "text", text: text.to_s } ] }
+        end
       end
 
       def document_part(doc)

--- a/app/services/llm/config.rb
+++ b/app/services/llm/config.rb
@@ -53,5 +53,22 @@ module Llm
     def asr_mode
       (@options[:asr_mode] || @options["asr_mode"]).to_s == "translate" ? :translate : :transcribe
     end
+
+    # How a document session spends its OCR call:
+    #   :extract (default)            — read the document to text, then structure
+    #                                   from that text. Two calls; the extracted
+    #                                   text is persisted as the Transcript.
+    #   :extract_and_structure        — one vision call straight to the form
+    #                                   fields. No text is emitted, so there is
+    #                                   no audit trail — and that is the saving:
+    #                                   output tokens cost ~6x input, and the
+    #                                   text is the bulk of them.
+    # Set options["ocr_mode"] on the OCR ModelAssignment. The orchestrator gates
+    # it further (single output, few pages, capable model); anything absent or
+    # unknown falls back to :extract.
+    def ocr_mode
+      value = (@options[:ocr_mode] || @options["ocr_mode"]).to_s
+      value == "extract_and_structure" ? :extract_and_structure : :extract
+    end
   end
 end

--- a/app/services/scribe/orchestrator.rb
+++ b/app/services/scribe/orchestrator.rb
@@ -228,8 +228,11 @@ module Scribe
       # A transcript output IS the text — combining would make it permanently
       # empty. More than one output would re-send the document per output,
       # which costs MORE than one OCR feeding N cheap text calls.
+      # Form only. A transcript output IS the text, and a note output has its
+      # own field/prompt/result shape (see #process_note_output) that this path
+      # does not reproduce — it would return a form-shaped result.
       return false unless outputs.one?
-      return false if outputs.first.output_type == "transcript"
+      return false unless outputs.first.output_type == "form"
       # Pages, not bytes: the guard the OCR path relies on (a truncated read) is
       # unfireable here, because the response is ~150 tokens of JSON against a
       # 4096 floor. A short report keeps a silently half-read document out of
@@ -246,9 +249,16 @@ module Scribe
       false
     end
 
+    # Adapter-aware on purpose. The Anthropic adapter always forces a tool call,
+    # so can_structure is enough. The OpenAI-compatible adapter constrains the
+    # response ONLY via response_format when supports_json_schema is set — it
+    # sends no tools — so a model carrying just supports_function_calling would
+    # get no schema constraint at all and return free-form text.
     def structuring_capable?(config)
-      config.capability?(:can_structure) &&
-        (config.capability?(:supports_json_schema) || config.capability?(:supports_function_calling))
+      return false unless config.capability?(:can_structure)
+      return true if config.provider_kind == :anthropic
+
+      config.capability?(:supports_json_schema)
     end
 
     # Runs the single output through one vision call. Mirrors #call's per-output
@@ -309,8 +319,11 @@ module Scribe
       ).call(COMBINED_PROMPT, documents: documents!)
     end
 
+    # Idempotent: a :partial output is retried on re-commit and lands here
+    # again, and Transcript is a has_one — a second create would either violate
+    # the constraint or leave two rows.
     def persist_stub_transcript!(stage)
-      Transcript.create!(
+      session.reload.transcript || Transcript.create!(
         scribe_session: session, text: nil, language: session.language,
         provider: stage.provider, model: stage.model
       )

--- a/app/services/scribe/orchestrator.rb
+++ b/app/services/scribe/orchestrator.rb
@@ -28,11 +28,20 @@ module Scribe
 
     NOTE_KEY = "note".freeze
 
+    # Combined extraction is for a short report — see #combined_extraction?.
+    MAX_COMBINED_PAGES = 2
+    # The "transcript" a combined run structures from: there is none, so say so
+    # rather than sending an empty string, which reads as "the document was
+    # blank" to a model that is also being handed the document itself.
+    COMBINED_PROMPT = "Read the attached document and fill the fields from it.".freeze
+
     def initialize(scribe_session)
       @session = scribe_session
     end
 
     def call
+      return call_combined if combined_extraction?
+
       transcript = ensure_transcript!
       return @session if transcript.nil? && transcript_failed?
 
@@ -201,21 +210,170 @@ module Scribe
     # text as the Transcript, and meters the attempt as function: :ocr
     # (dedupe "{session}:ocr"). Structuring then consumes the transcript text
     # exactly as it does for audio.
-    def transcript_from_documents!
-      config = Llm::ConfigResolver.call(function: :ocr, account: session.account)
+    # One vision call straight to the form fields, instead of OCR-then-structure.
+    #
+    # Cheaper because it never emits the extracted text: output tokens cost ~6x
+    # input and the text is the bulk of them, so this is ~3x on a one-page
+    # report. The text is exactly what it gives up, which is why every gate
+    # below is about making sure nobody is relying on it.
+    #
+    # Fails CLOSED to the two-call path — never a 4xx. The mode is an operator's
+    # server-side assignment that can change between create and commit, so
+    # refusing would blame the client for a decision they did not make.
+    def combined_extraction?
+      return false unless session.modality_document?
+      return false unless ocr_config.ocr_mode == :extract_and_structure
 
-      # Sorted by attachment id, which is upload order, which is the order the
-      # client intended the report to read in. The association carries no ORDER
-      # BY of its own, so page 3 of a split report could otherwise be transcribed
-      # ahead of page 1 and the extracted text would interleave silently.
-      documents = session.document_files.attachments.sort_by(&:id).map do |file|
-        {
-          data: file.blob.download,
-          content_type: file.blob.content_type,
-          filename: file.blob.filename.to_s
-        }
+      outputs = session.scribe_outputs.to_a
+      # A transcript output IS the text — combining would make it permanently
+      # empty. More than one output would re-send the document per output,
+      # which costs MORE than one OCR feeding N cheap text calls.
+      return false unless outputs.one?
+      return false if outputs.first.output_type == "transcript"
+      # Pages, not bytes: the guard the OCR path relies on (a truncated read) is
+      # unfireable here, because the response is ~150 tokens of JSON against a
+      # 4096 floor. A short report keeps a silently half-read document out of
+      # the realistic failure set.
+      return false if session.document_pages > MAX_COMBINED_PAGES
+      # The model must actually be able to return schema-valid JSON, and so must
+      # its fallback — ConfigResolver hands the fallback the primary's options,
+      # so it would otherwise inherit the mode without the capability.
+      structuring_capable?(ocr_config) &&
+        (ocr_config.fallback.nil? || structuring_capable?(ocr_config.fallback))
+    rescue StandardError => e
+      # Resolving config must never be what fails a session.
+      Rails.logger.warn("combined extraction check failed for session=#{session.id}: #{e.class}")
+      false
+    end
+
+    def structuring_capable?(config)
+      config.capability?(:can_structure) &&
+        (config.capability?(:supports_json_schema) || config.capability?(:supports_function_calling))
+    end
+
+    # Runs the single output through one vision call. Mirrors #call's per-output
+    # isolation, metering and rollup so nothing downstream can tell the
+    # difference except that the transcript carries no text.
+    def call_combined
+      output = session.scribe_outputs.first
+      unless output.status_success?
+        stage = process_combined_output(output)
+        meter_combined(stage) if stage
       end
-      raise Llm::Error, "no documents attached to scribe session" if documents.empty?
+      finalize_session_status!
+      session
+    end
+
+    def process_combined_output(output)
+      stage = combined_stage_for(output)
+      output.result = stage.structured
+      # :partial, not :failure, and result_errors only when there are some —
+      # the column is NOT NULL. Same shape as the split path's form output, so
+      # the rollup and the UI cannot tell which path produced it.
+      if stage.valid
+        output.status = :success
+      else
+        output.status = :partial
+        output.result_errors = stage.errors
+      end
+      output.save!
+      # A stub Transcript keeps `session.transcript.present?` meaning "this
+      # session has been extracted", which is the re-commit short-circuit and
+      # the admin/UI signal. text is nil because none was ever emitted; the UI
+      # already has an honest branch for that.
+      persist_stub_transcript!(stage)
+      stage
+    rescue Llm::Error => e
+      meter_failed_attempt(e)
+      mark_transcript_failure!(e, client_message_for(e))
+      @transcript_failed = true
+      nil
+    rescue StandardError => e
+      mark_transcript_failure!(e, client_message_for(e))
+      @transcript_failed = true
+      nil
+    end
+
+    def combined_stage_for(output)
+      if output.inline_fields.present?
+        fields = Scribe::InlineField.build_all(output.inline_fields)
+        system_prompt = nil
+      else
+        fields = output.page.form_fields.to_a
+        system_prompt = output.page.prompt
+      end
+
+      Scribe::StructuringStage.new(
+        config: ocr_config, fields: fields,
+        context: output.context, system_prompt: system_prompt
+      ).call(COMBINED_PROMPT, documents: documents!)
+    end
+
+    def persist_stub_transcript!(stage)
+      Transcript.create!(
+        scribe_session: session, text: nil, language: session.language,
+        provider: stage.provider, model: stage.model
+      )
+    end
+
+    # One UsageEvent, function :ocr — the call IS the OCR call, and keying it
+    # :ocr keeps ocr_attempt_number, the per-page price component and the
+    # existing ledger semantics intact. Keyed explicitly rather than through
+    # dedupe_key_for's per-output branch, which carries no attempt counter.
+    # Keyed with no scribe_output, so dedupe_key_for yields the per-attempt
+    # "{session}:ocr:{n}" form rather than the output-keyed one, which carries
+    # no attempt counter.
+    def meter_combined(stage)
+      meter(function: :ocr, stage: stage, usage: usage_with_pages(stage.usage))
+    end
+
+    def usage_with_pages(usage)
+      return usage unless usage
+
+      Llm::Usage.new(
+        input_tokens: usage.input_tokens, output_tokens: usage.output_tokens,
+        audio_seconds: usage.audio_seconds, pages: session.document_pages,
+        estimated: usage.estimated
+      )
+    end
+
+    # Sorted by attachment id, which is upload order, which is the order the
+    # client intended the report to read in. The association carries no ORDER BY
+    # of its own, so page 3 of a split report could otherwise be read ahead of
+    # page 1 and the text would interleave silently.
+    def documents!
+      @documents ||= begin
+        docs = session.document_files.attachments.sort_by(&:id).map do |file|
+          {
+            data: file.blob.download,
+            content_type: file.blob.content_type,
+            filename: file.blob.filename.to_s
+          }
+        end
+        raise Llm::Error, "no documents attached to scribe session" if docs.empty?
+
+        docs
+      end
+    end
+
+    def ocr_config
+      @ocr_config ||= Llm::ConfigResolver.call(
+        function: :ocr, page: shared_page, account: session.account
+      )
+    end
+
+    # The page every output shares, when they share one — so an OCR assignment
+    # made at Page or Template scope is actually reachable. nil (today's
+    # behaviour) when the outputs span pages and no single scope applies.
+    def shared_page
+      pages = session.scribe_outputs.map(&:page).uniq
+      pages.size == 1 ? pages.first : nil
+    end
+
+    def transcript_from_documents!
+      config = ocr_config
+
+      documents = documents!
 
       stage = Scribe::OcrStage.new(config: config).call(
         documents, pages: session.document_pages
@@ -437,8 +595,8 @@ module Scribe
     # output or fail the session. A usage_event left :pending by such a failure
     # is swept to :failed by Metering::ReservationSweeper; holds are postpaid, so
     # no credit balance is returned.
-    def meter(function:, stage:, scribe_output: nil)
-      record_and_deduct(function: function, stage: stage, scribe_output: scribe_output)
+    def meter(function:, stage:, scribe_output: nil, usage: nil)
+      record_and_deduct(function: function, stage: stage, scribe_output: scribe_output, usage: usage)
     rescue StandardError => e
       Rails.logger.error(
         "Scribe::Orchestrator metering failed for session=#{session.id} " \
@@ -454,11 +612,11 @@ module Scribe
     # NOT respond to #latency_ms, but Metering::UsageRecorder consumes the
     # Llm::Result contract (usage / provider / model / latency_ms). Wrap the
     # stage struct into an Llm::Result so the meter sees the shape it expects.
-    def record_and_deduct(function:, stage:, scribe_output: nil)
+    def record_and_deduct(function:, stage:, scribe_output: nil, usage: nil)
       event = Metering::UsageRecorder.record(
         account: session.account,
         function: function,
-        result: as_llm_result(stage),
+        result: as_llm_result(stage, usage: usage),
         api_token: session.api_token,
         scribe_session: session,
         scribe_output: scribe_output,
@@ -512,13 +670,15 @@ module Scribe
     # The stage structs carry latency_ms (ASR/OCR from the adapter, structuring
     # timed across the whole stage so a repair re-ask is counted), so it reaches
     # usage_events; the respond_to? guard remains for any struct that does not.
-    def as_llm_result(stage)
+    # `usage` overrides the stage's own — a combined run grafts the page count
+    # on, which only OcrStage does for itself.
+    def as_llm_result(stage, usage: nil)
       Llm::Result.new(
         text: stage.respond_to?(:text) ? stage.text : nil,
         structured: stage.respond_to?(:structured) ? stage.structured : nil,
         model: stage.model,
         provider: stage.provider,
-        usage: stage.usage,
+        usage: usage || stage.usage,
         latency_ms: stage.respond_to?(:latency_ms) ? stage.latency_ms : nil,
         finish_reason: stage.respond_to?(:finish_reason) ? stage.finish_reason : nil,
         raw: stage.respond_to?(:raw) ? stage.raw : nil

--- a/app/services/scribe/structuring_stage.rb
+++ b/app/services/scribe/structuring_stage.rb
@@ -23,7 +23,11 @@ module Scribe
       @system_prompt = system_prompt
     end
 
-    def call(transcript_text)
+    # `documents` structures directly from the source file — one vision call
+    # instead of OCR-then-structure. The repair re-ask deliberately does NOT
+    # re-send them: the previous JSON and the validation errors are already in
+    # the repair prompt, so paying to re-read the document buys nothing.
+    def call(transcript_text, documents: nil, max_tokens: nil)
       # Timed over the whole stage rather than taken from llm.latency_ms: a
       # failed validation triggers a repair re-ask, which is a SECOND provider
       # round-trip, and the first call's latency would silently undercount the
@@ -32,7 +36,11 @@ module Scribe
       repaired = false
 
       model_schema = builder.call
-      llm = Llm::Caller.structure(@config, messages: messages(transcript_text), schema: model_schema)
+      llm = Llm::Caller.structure(
+        @config,
+        messages: messages(transcript_text), schema: model_schema,
+        documents: documents, max_tokens: max_tokens
+      )
       guard_completion!(llm)
 
       data, errors = validator.validate_and_repair(llm.structured) do |errs|

--- a/docs/api/v2.md
+++ b/docs/api/v2.md
@@ -207,7 +207,10 @@ order and sequentially* — a report photographed a page at a time is transcribe
 in upload order. Racing the calls is safe but shuffles the pages.
 
 At commit, a vision model extracts the complete document text in a single call
-across every attached file. That text is persisted as the session's
+across every attached file. (An operator can instead enable combined
+extraction, which fills the declared form in one call and emits no text — the
+session's `transcript.text` is then `null`. It applies only to a short,
+single-output session; anything else uses the two-call path below.) That text is persisted as the session's
 `transcript` — the audit trail of what the model actually read — and the
 declared outputs are then structured from it exactly as for audio. An
 extraction that hits the model's output budget is a **failure**, never a
@@ -413,7 +416,7 @@ Optional params (all backward compatible):
 | Field | Description |
 | --- | --- |
 | `modality` | `audio`, `document`, or `pending` for a session created without one that has not yet been uploaded to. Fixed by the first upload the server stores, and immutable after that. Treat it as an open set: a client that switches on it must tolerate `pending`. |
-| `transcript` | The extracted source text — OCR output for a `document` session, ASR output for an `audio` one — as `{ text, language }`, or `null` before it exists. **This is the top-level way to read OCR output**; it does not depend on having declared a `transcript` output. During an audio recording it carries the growing live transcript instead. |
+| `transcript` | The extracted source text — OCR output for a `document` session, ASR output for an `audio` one — as `{ text, language }`, or `null` before it exists. `text` is `null` on a completed document session when the operator has enabled combined extraction (`ocr_mode`), which fills the form in one vision call and never emits the text. The object itself is still present, so `transcript && transcript.text === null` distinguishes "no text was produced" from "not ready yet". **This is the top-level way to read OCR output**; it does not depend on having declared a `transcript` output. During an audio recording it carries the growing live transcript instead. |
 | `usage` | Per-session metering. `pages` is the quantity OCR is billed on; `audio_seconds` is the audio equivalent, and each is `0` for the other modality. `by_function` splits cost across `ocr` / `asr` / `structuring`. |
 
 Failed attempts (a provider response that was billed but could not be used —

--- a/docs/api/v2.md
+++ b/docs/api/v2.md
@@ -207,10 +207,14 @@ order and sequentially* — a report photographed a page at a time is transcribe
 in upload order. Racing the calls is safe but shuffles the pages.
 
 At commit, a vision model extracts the complete document text in a single call
-across every attached file. (An operator can instead enable combined
-extraction, which fills the declared form in one call and emits no text — the
-session's `transcript.text` is then `null`. It applies only to a short,
-single-output session; anything else uses the two-call path below.) That text is persisted as the session's
+across every attached file. **Combined extraction.** An operator can instead set `ocr_mode` to
+`"extract_and_structure"` on the account's OCR model assignment, which fills the
+declared form in ONE call and emits no text — the session's `transcript.text` is
+then `null`. It is used only when ALL of these hold, and silently falls back to
+the two-call path otherwise: the session declares exactly one output, that
+output is a `form`, the session is 2 pages or fewer, and the assigned model —
+and its fallback — can return schema-valid JSON. So handle `transcript.text:
+null` whenever your operator may have enabled it. That text is persisted as the session's
 `transcript` — the audit trail of what the model actually read — and the
 declared outputs are then structured from it exactly as for audio. An
 extraction that hits the model's output budget is a **failure**, never a

--- a/test/integration/api/v2/combined_extraction_test.rb
+++ b/test/integration/api/v2/combined_extraction_test.rb
@@ -1,0 +1,241 @@
+require "test_helper"
+
+module Api
+  module V2
+    # ocr_mode: "extract_and_structure" — one vision call straight to the form
+    # fields, no extracted text. The saving IS the transcript, so every gate
+    # here exists to make sure nobody relying on the text loses it silently.
+    class CombinedExtractionTest < ActionDispatch::IntegrationTest
+      CHAT_URL = "https://api.openai.com/v1/chat/completions".freeze
+
+      setup do
+        @account = create(:account)
+        @user = create(:user, account: @account)
+        @token = create(:api_token, user: @user, account: @account)
+        @headers = { "Authorization" => "Bearer #{@token.raw_token}" }
+        @prev = ENV["OPENAI_ACCESS_TOKEN"]
+        ENV["OPENAI_ACCESS_TOKEN"] = "test-key"
+
+        @page = create(:page)
+        create(:form_field, page: @page, title: "hemoglobin", friendly_name: "Hemoglobin", field_type: "string")
+      end
+
+      teardown { ENV["OPENAI_ACCESS_TOKEN"] = @prev }
+
+      # A vision model that can also return schema-valid JSON, assigned to :ocr
+      # with the combined mode switched on.
+      def assign_combined_ocr!(options: { "ocr_mode" => "extract_and_structure" }, capabilities: nil)
+        model = create(:ai_model, api_model_id: "gpt-4o-mini", capabilities: capabilities || {
+          "supports_vision" => true, "supports_pdf" => true,
+          "can_structure" => true, "supports_json_schema" => true
+        })
+        create(:model_assignment, scope_type: "System", scope_id: nil, function: "ocr",
+                                  ai_model: model, options: options)
+        model
+      end
+
+      def stub_structured(fields = { hemoglobin: "13.5" }, usage: { prompt_tokens: 1500, completion_tokens: 150 })
+        stub_request(:post, CHAT_URL).to_return(
+          status: 200, headers: { "Content-Type" => "application/json" },
+          body: { choices: [ { message: { content: fields.to_json }, finish_reason: "stop" } ],
+                  usage: usage }.to_json
+        )
+      end
+
+      def document_session(outputs: [ { type: "form", page_id: nil } ], pages: 1)
+        outputs = outputs.map { |o| o[:page_id].nil? && o[:type] == "form" ? o.merge(page_id: @page.id) : o }
+        post "/api/v2/scribe_sessions",
+             params: { modality: "document", outputs: outputs }.to_json,
+             headers: @headers.merge("Content-Type" => "application/json")
+        id = JSON.parse(response.body)["id"]
+        post "/api/v2/scribe_sessions/#{id}/documents",
+             params: { document: pdf_upload(pages: pages) }, headers: @headers
+        assert_response :ok
+        id
+      end
+
+      test "one provider call fills the form and the run completes" do
+        assign_combined_ocr!
+        stub_structured
+        id = document_session
+
+        post "/api/v2/scribe_sessions/#{id}/commit", headers: @headers
+        assert_response :accepted
+
+        get "/api/v2/scribe_sessions/#{id}", headers: @headers
+        body = JSON.parse(response.body)
+        assert_equal "completed", body["status"]
+        assert_equal "13.5", body["outputs"].sole.dig("result", "hemoglobin")
+        # Exactly one round-trip — that is the whole point.
+        assert_requested :post, CHAT_URL, times: 1
+      end
+
+      test "no extracted text is emitted, and the transcript says so" do
+        assign_combined_ocr!
+        stub_structured
+        id = document_session
+        post "/api/v2/scribe_sessions/#{id}/commit", headers: @headers
+
+        get "/api/v2/scribe_sessions/#{id}", headers: @headers
+        body = JSON.parse(response.body)
+        # A present object with a null text, NOT a bare null: null already means
+        # "not ready yet", and a client polling on it against a terminal 200
+        # would spin forever.
+        assert body.key?("transcript")
+        assert_not_nil body["transcript"]
+        assert_nil body.dig("transcript", "text")
+        assert_nil ScribeSession.find(id).transcript.text
+      end
+
+      test "it is metered once as ocr, carrying the page count" do
+        assign_combined_ocr!
+        stub_structured
+        id = document_session(pages: 2)
+        post "/api/v2/scribe_sessions/#{id}/commit", headers: @headers
+
+        events = UsageEvent.where(scribe_session_id: id)
+        assert_equal 1, events.count
+        event = events.sole
+        assert_equal "ocr", event.function
+        assert_equal "finalized", event.status
+        assert_equal 2, event.pages, "the per-page quantity must survive"
+        assert_equal "#{id}:ocr:0", event.dedupe_key
+        # No structuring event: there was no second call to meter.
+        assert_equal 0, UsageEvent.where(scribe_session_id: id, function: "structuring").count
+      end
+
+      # ── the gates: each falls back to the two-call path, never a 4xx ──────
+
+      test "a declared transcript output keeps the two-call path" do
+        assign_combined_ocr!
+        # OCR text, then structuring JSON — two calls.
+        stub_request(:post, CHAT_URL).to_return(
+          { status: 200, headers: { "Content-Type" => "application/json" },
+            body: { choices: [ { message: { content: "Hemoglobin 13.5" }, finish_reason: "stop" } ],
+                    usage: { prompt_tokens: 900, completion_tokens: 100 } }.to_json },
+          { status: 200, headers: { "Content-Type" => "application/json" },
+            body: { choices: [ { message: { content: { hemoglobin: "13.5" }.to_json }, finish_reason: "stop" } ],
+                    usage: { prompt_tokens: 200, completion_tokens: 20 } }.to_json }
+        )
+        id = document_session(outputs: [ { type: "transcript" }, { type: "form", page_id: nil } ])
+
+        post "/api/v2/scribe_sessions/#{id}/commit", headers: @headers
+
+        session = ScribeSession.find(id)
+        assert_equal "completed", session.status
+        assert_includes session.transcript.text, "Hemoglobin", "the text must still exist"
+        assert_requested :post, CHAT_URL, times: 2
+      end
+
+      test "more than one output keeps the two-call path" do
+        assign_combined_ocr!
+        second = create(:page, template: @page.template)
+        create(:form_field, page: second, title: "wbc", friendly_name: "WBC", field_type: "string")
+        stub_request(:post, CHAT_URL).to_return(
+          status: 200, headers: { "Content-Type" => "application/json" },
+          body: { choices: [ { message: { content: { hemoglobin: "13.5" }.to_json }, finish_reason: "stop" } ],
+                  usage: { prompt_tokens: 900, completion_tokens: 100 } }.to_json
+        )
+        id = document_session(outputs: [ { type: "form", page_id: @page.id },
+                                         { type: "form", page_id: second.id } ])
+
+        post "/api/v2/scribe_sessions/#{id}/commit", headers: @headers
+
+        # The split path: an extracted transcript exists, and there was more
+        # than one call. Not pinned to an exact count — a schema-repair re-ask
+        # legitimately adds one and is not what this test is about.
+        assert_not_nil ScribeSession.find(id).transcript.text
+        assert_requested :post, CHAT_URL, at_least_times: 3
+      end
+
+      test "a report longer than the page limit keeps the two-call path" do
+        assign_combined_ocr!
+        stub_request(:post, CHAT_URL).to_return(
+          status: 200, headers: { "Content-Type" => "application/json" },
+          body: { choices: [ { message: { content: { hemoglobin: "13.5" }.to_json }, finish_reason: "stop" } ],
+                  usage: { prompt_tokens: 900, completion_tokens: 100 } }.to_json
+        )
+        id = document_session(pages: Scribe::Orchestrator::MAX_COMBINED_PAGES + 1)
+
+        post "/api/v2/scribe_sessions/#{id}/commit", headers: @headers
+
+        assert_requested :post, CHAT_URL, times: 2
+        assert_not_nil ScribeSession.find(id).transcript.text
+      end
+
+      test "a model that cannot return structured JSON keeps the two-call path" do
+        assign_combined_ocr!(capabilities: { "supports_vision" => true, "supports_pdf" => true })
+        stub_request(:post, CHAT_URL).to_return(
+          status: 200, headers: { "Content-Type" => "application/json" },
+          body: { choices: [ { message: { content: { hemoglobin: "13.5" }.to_json }, finish_reason: "stop" } ],
+                  usage: { prompt_tokens: 900, completion_tokens: 100 } }.to_json
+        )
+        id = document_session
+
+        post "/api/v2/scribe_sessions/#{id}/commit", headers: @headers
+
+        assert_requested :post, CHAT_URL, times: 2
+      end
+
+      test "the mode is off by default" do
+        assign_combined_ocr!(options: {})
+        stub_request(:post, CHAT_URL).to_return(
+          status: 200, headers: { "Content-Type" => "application/json" },
+          body: { choices: [ { message: { content: { hemoglobin: "13.5" }.to_json }, finish_reason: "stop" } ],
+                  usage: { prompt_tokens: 900, completion_tokens: 100 } }.to_json
+        )
+        id = document_session
+
+        post "/api/v2/scribe_sessions/#{id}/commit", headers: @headers
+        assert_requested :post, CHAT_URL, times: 2
+      end
+
+      # ── failure ──────────────────────────────────────────────────────────
+
+      test "a failed combined call fails the session with a generic message" do
+        assign_combined_ocr!
+        stub_request(:post, CHAT_URL).to_return(status: 500, body: "boom")
+        id = document_session
+
+        post "/api/v2/scribe_sessions/#{id}/commit", headers: @headers
+
+        session = ScribeSession.find(id)
+        assert_equal "failed", session.status
+        assert_equal [ "failure" ], session.scribe_outputs.map(&:status).uniq
+        assert_nil session.transcript, "nothing was extracted, so no stub transcript"
+      end
+
+      # An unusable-but-billed 200 must still reach the ledger, exactly as the
+      # split path does.
+      test "a billed-but-unusable combined attempt is recorded as failed" do
+        assign_combined_ocr!
+        stub_request(:post, CHAT_URL).to_return(
+          status: 200, headers: { "Content-Type" => "application/json" },
+          body: { choices: [ { message: { content: "half" }, finish_reason: "length" } ],
+                  usage: { prompt_tokens: 1500, completion_tokens: 4096 } }.to_json
+        )
+        id = document_session
+
+        post "/api/v2/scribe_sessions/#{id}/commit", headers: @headers
+
+        assert_equal "failed", ScribeSession.find(id).status
+        event = UsageEvent.find_by(scribe_session_id: id, function: "ocr")
+        assert event, "the billed attempt was absorbed silently"
+        assert_equal "failed", event.status
+        assert_equal 4096, event.output_tokens
+      end
+
+      private
+
+      def pdf_upload(pages: 1)
+        file = Tempfile.new([ "report", ".pdf" ])
+        file.binmode
+        file.write(minimal_pdf(pages: pages))
+        file.rewind
+        Rack::Test::UploadedFile.new(file.path, "application/pdf")
+      end
+
+      include PdfFixtures
+    end
+  end
+end

--- a/test/integration/api/v2/combined_extraction_test.rb
+++ b/test/integration/api/v2/combined_extraction_test.rb
@@ -190,6 +190,65 @@ module Api
         assert_requested :post, CHAT_URL, times: 2
       end
 
+      # OpenaiCompatible#structure constrains the response only via
+      # response_format when supports_json_schema is set — it sends no tools —
+      # so function-calling alone would mean no schema constraint at all.
+      test "supports_function_calling alone is not enough on an openai-compatible model" do
+        assign_combined_ocr!(capabilities: {
+          "supports_vision" => true, "supports_pdf" => true,
+          "can_structure" => true, "supports_function_calling" => true
+        })
+        stub_request(:post, CHAT_URL).to_return(
+          status: 200, headers: { "Content-Type" => "application/json" },
+          body: { choices: [ { message: { content: { hemoglobin: "13.5" }.to_json }, finish_reason: "stop" } ],
+                  usage: { prompt_tokens: 900, completion_tokens: 100 } }.to_json
+        )
+        id = document_session
+
+        post "/api/v2/scribe_sessions/#{id}/commit", headers: @headers
+
+        assert_requested :post, CHAT_URL, times: 2
+        assert_not_nil ScribeSession.find(id).transcript.text
+      end
+
+      # A note output has its own field, prompt and { note: ... } result shape;
+      # the combined path would return a form-shaped result.
+      test "a note output keeps the two-call path" do
+        assign_combined_ocr!
+        stub_request(:post, CHAT_URL).to_return(
+          status: 200, headers: { "Content-Type" => "application/json" },
+          body: { choices: [ { message: { content: { note: "text" }.to_json }, finish_reason: "stop" } ],
+                  usage: { prompt_tokens: 900, completion_tokens: 100 } }.to_json
+        )
+        id = document_session(outputs: [ { type: "note" } ])
+
+        post "/api/v2/scribe_sessions/#{id}/commit", headers: @headers
+
+        session = ScribeSession.find(id)
+        assert_not_nil session.transcript.text
+        assert_equal "text", session.scribe_outputs.sole.result["note"]
+      end
+
+      # A :partial output is retried on re-commit and reaches the stub-transcript
+      # write again. Transcript is a has_one — a second create would duplicate.
+      test "re-committing a partial combined run does not duplicate the transcript" do
+        assign_combined_ocr!
+        # Schema-invalid: the field is missing, so the output lands :partial.
+        stub_request(:post, CHAT_URL).to_return(
+          status: 200, headers: { "Content-Type" => "application/json" },
+          body: { choices: [ { message: { content: { wrong_key: "x" }.to_json }, finish_reason: "stop" } ],
+                  usage: { prompt_tokens: 900, completion_tokens: 100 } }.to_json
+        )
+        id = document_session
+
+        post "/api/v2/scribe_sessions/#{id}/commit", headers: @headers
+        assert_equal 1, Transcript.where(scribe_session_id: id).count
+
+        post "/api/v2/scribe_sessions/#{id}/commit", headers: @headers
+        assert_equal 1, Transcript.where(scribe_session_id: id).count,
+                     "the retry created a second transcript row"
+      end
+
       # ── failure ──────────────────────────────────────────────────────────
 
       test "a failed combined call fails the session with a generic message" do


### PR DESCRIPTION
A document session can fill its form in **one** vision call instead of
OCR-then-structure. Off by default; enable per scope with
`{"ocr_mode": "extract_and_structure"}` on the OCR `ModelAssignment`.

## The saving is the transcript, not the round-trip

Output tokens cost ~6x input and the extracted text is the bulk of them.
Costed through `PriceBook` with the **deployed** models:

| deployment, 1 page | today | combined | |
| --- | --- | --- | --- |
| gemini-3.7-flash + gpt-4.1-mini | $0.00326 | $0.00102 | **3.2x** |
| gemini-3.7-flash + llama-3.3-70b (Page-1 override) | $0.00270 | $0.00102 | **2.7x** |
| gpt-5.6-luna both ends | $0.00099 | $0.00029 | **3.5x** |

The variant that keeps the text is **not built**: ~10% at one output, and
*more expensive than today* on the existing Page-1 llama override.

## Gates — fails closed to the two-call path, never a 4xx

Refusing would blame the client for an operator's assignment that can change
between create and commit. Combined runs only when all hold:

- exactly one declared output, and it is not a `transcript` output (that output *is* the text)
- `document_pages <= 2`
- the model **and its fallback** can return schema-valid JSON — `ConfigResolver`
  hands the fallback the primary's `options`, so without that check a fallback
  would inherit the mode without the capability

Out of the box it is off: the OCR catalog stamps vision only, so nobody gets
this until they opt in.

## Contract

A stub `Transcript` (`text: nil`) is still written, so `session.transcript.present?`
keeps meaning "extracted" — the re-commit short-circuit and the admin/UI signal.
The API returns `{"text": null}`, **not** a bare `null`: null already means "not
ready yet", and a client polling `if (!resp.transcript)` against a terminal 200
would spin forever.

Metered as one `:ocr` event keyed `{session}:ocr:{n}`, with the page count
grafted on so the per-page quantity and any per-page price component survive.

## Test plan

- [x] `bin/rails test` — 646 runs, 2419 assertions, 0 failures
- [x] `bin/rubocop` — clean (294 files) · `bin/brakeman` — 0 warnings
- [x] 10 new integration tests: the happy path (asserting **exactly one**
      provider call), null-text contract, metering/dedupe/pages, and one test
      per gate proving each falls back to the two-call path

## Not in this PR

Per-output dedupe keys carry no attempt counter, so a re-committed partial
output's second billed structuring call collides and is swallowed. Pre-existing
on the cheap text path and unrelated to this gate — separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional combined document extraction mode for eligible short, single-output forms.
  - Combined processing can extract structured results in one vision call without generating transcript text.
  - Added support for document inputs and configurable token limits during structured extraction.
  - Added OCR mode configuration and expanded usage tracking with document page counts.

- **Bug Fixes**
  - Unsupported configurations automatically fall back to the existing two-step extraction workflow.
  - Improved handling and reporting of incomplete or unusable document-processing attempts.

- **Documentation**
  - Updated API documentation to explain combined extraction and absent transcripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->