### PR TITLE
Say why a configured combined extraction was skipped

### DIFF
--- a/app/services/scribe/orchestrator.rb
+++ b/app/services/scribe/orchestrator.rb
@@ -224,36 +224,69 @@ module Scribe
       return false unless session.modality_document?
       return false unless ocr_config.ocr_mode == :extract_and_structure
 
-      outputs = session.scribe_outputs.to_a
-      # A transcript output IS the text — combining would make it permanently
-      # empty. More than one output would re-send the document per output,
-      # which costs MORE than one OCR feeding N cheap text calls.
-      # Form only. A transcript output IS the text, and a note output has its
-      # own field/prompt/result shape (see #process_note_output) that this path
-      # does not reproduce — it would return a form-shaped result.
-      return false unless outputs.one?
-      return false unless outputs.first.output_type == "form"
-      # Pages, not bytes: the guard the OCR path relies on (a truncated read) is
-      # unfireable here, because the response is ~150 tokens of JSON against a
-      # 4096 floor. A short report keeps a silently half-read document out of
-      # the realistic failure set.
-      return false if session.document_pages > MAX_COMBINED_PAGES
-      # The model must actually be able to return schema-valid JSON, and so must
-      # its fallback — ConfigResolver hands the fallback the primary's options,
-      # so it would otherwise inherit the mode without the capability.
-      structuring_capable?(ocr_config) &&
-        (ocr_config.fallback.nil? || structuring_capable?(ocr_config.fallback))
+      reason = combined_skip_reason
+      if reason
+        # The operator switched this on and is not getting it. Silence here is
+        # how a deliberate config comes to look broken, so say which guard
+        # refused and why.
+        Rails.logger.info(
+          "Scribe::Orchestrator combined extraction skipped for session=#{session.id}: #{reason}"
+        )
+        return false
+      end
+      true
     rescue StandardError => e
       # Resolving config must never be what fails a session.
       Rails.logger.warn("combined extraction check failed for session=#{session.id}: #{e.class}")
       false
     end
 
-    # Adapter-aware on purpose. The Anthropic adapter always forces a tool call,
-    # so can_structure is enough. The OpenAI-compatible adapter constrains the
-    # response ONLY via response_format when supports_json_schema is set — it
-    # sends no tools — so a model carrying just supports_function_calling would
-    # get no schema constraint at all and return free-form text.
+    # nil when the session is eligible, else why it is not — in the operator's
+    # terms, not the code's.
+    def combined_skip_reason
+      outputs = session.scribe_outputs.to_a
+
+      # A transcript output IS the extracted text, which this path never
+      # produces. Checked BEFORE the count: a transcript output costs no
+      # provider call (it echoes the persisted text), so "too many outputs"
+      # would be the wrong diagnosis for the common transcript+form session.
+      if outputs.any? { |o| o.output_type == "transcript" }
+        return "a transcript output was declared, and combined extraction emits no text — " \
+               "drop it to use combined extraction"
+      end
+
+      # Only outputs that actually cost a provider call count: re-sending the
+      # document per output is what makes combining more expensive, not echoes.
+      billable = outputs.reject { |o| o.output_type == "transcript" }
+      return "no output to fill" if billable.empty?
+
+      if billable.size > 1
+        return "#{billable.size} outputs declared — combining re-sends the document per output, " \
+               "which costs more than one extraction feeding them all"
+      end
+
+      unless billable.first.output_type == "form"
+        return "the output is a #{billable.first.output_type}, which has its own result shape; " \
+               "combined extraction fills form outputs only"
+      end
+
+      if session.document_pages > MAX_COMBINED_PAGES
+        return "#{session.document_pages} pages, over the #{MAX_COMBINED_PAGES}-page limit for combined extraction"
+      end
+
+      unless structuring_capable?(ocr_config)
+        return "#{ocr_config.api_model_id} is not marked able to return schema-valid JSON " \
+               "(needs can_structure, plus supports_json_schema unless it is an Anthropic model)"
+      end
+
+      if ocr_config.fallback && !structuring_capable?(ocr_config.fallback)
+        return "the fallback #{ocr_config.fallback.api_model_id} cannot return schema-valid JSON, " \
+               "and it would inherit this mode"
+      end
+
+      nil
+    end
+
     def structuring_capable?(config)
       return false unless config.capability?(:can_structure)
       return true if config.provider_kind == :anthropic

--- a/test/integration/api/v2/combined_extraction_test.rb
+++ b/test/integration/api/v2/combined_extraction_test.rb
@@ -249,6 +249,47 @@ module Api
                      "the retry created a second transcript row"
       end
 
+      # Production, 2026-08-17: ocr_mode was set and every session still took
+      # the two-call path, with no signal anywhere as to why. The operator has
+      # to be able to find out.
+      test "skipping a configured combined run says which guard refused" do
+        assign_combined_ocr!
+        stub_request(:post, CHAT_URL).to_return(
+          status: 200, headers: { "Content-Type" => "application/json" },
+          body: { choices: [ { message: { content: { hemoglobin: "13.5" }.to_json }, finish_reason: "stop" } ],
+                  usage: { prompt_tokens: 900, completion_tokens: 100 } }.to_json
+        )
+        id = document_session(outputs: [ { type: "transcript" }, { type: "form", page_id: nil } ])
+
+        logged = capture_orchestrator_log do
+          post "/api/v2/scribe_sessions/#{id}/commit", headers: @headers
+        end
+
+        assert_match(/combined extraction skipped for session=#{id}/, logged)
+        # The RIGHT reason: a transcript output costs no provider call, so
+        # "too many outputs" would be a misleading diagnosis for this shape.
+        assert_match(/transcript output was declared/, logged)
+        assert_no_match(/2 outputs declared/, logged)
+      end
+
+      test "a two-form session is refused for the cost reason, not the transcript one" do
+        assign_combined_ocr!
+        second = create(:page, template: @page.template)
+        create(:form_field, page: second, title: "wbc", friendly_name: "WBC", field_type: "string")
+        stub_request(:post, CHAT_URL).to_return(
+          status: 200, headers: { "Content-Type" => "application/json" },
+          body: { choices: [ { message: { content: { hemoglobin: "13.5" }.to_json }, finish_reason: "stop" } ],
+                  usage: { prompt_tokens: 900, completion_tokens: 100 } }.to_json
+        )
+        id = document_session(outputs: [ { type: "form", page_id: @page.id },
+                                         { type: "form", page_id: second.id } ])
+
+        logged = capture_orchestrator_log do
+          post "/api/v2/scribe_sessions/#{id}/commit", headers: @headers
+        end
+        assert_match(/2 outputs declared/, logged)
+      end
+
       # ── failure ──────────────────────────────────────────────────────────
 
       test "a failed combined call fails the session with a generic message" do
@@ -285,6 +326,16 @@ module Api
       end
 
       private
+
+      def capture_orchestrator_log
+        io = StringIO.new
+        previous = Rails.logger
+        Rails.logger = ActiveSupport::Logger.new(io)
+        yield
+        io.string
+      ensure
+        Rails.logger = previous
+      end
 
       def pdf_upload(pages: 1)
         file = Tempfile.new([ "report", ".pdf" ])


### PR DESCRIPTION
`ocr_mode: "extract_and_structure"` was set in production and every document session still took the two-call path — with **no signal anywhere** as to why. A deliberate operator config that silently does nothing looks broken, and that was on me.

Every gate now produces a reason, logged at info:

```
combined extraction skipped for session=280: a transcript output was declared,
and combined extraction emits no text — drop it to use combined extraction
```

The first guard was also giving the **wrong** reason. It counted all outputs, but a `transcript` output costs no provider call — `process_transcript_output` just echoes the persisted text. So the common `transcript+form` session was refused as "too many outputs" when the actual reason is that a transcript output *is* the text combined extraction doesn't produce. Transcript is now checked first, and the count guard only counts outputs that cost a call.

**No behaviour change** — the same sessions are refused, for the same underlying reasons. They can now be diagnosed instead of guessed at.

## Test plan
- [x] `bin/rails test` — 651 runs, 0 failures
- [x] rubocop + brakeman clean
- [x] Two new tests: the transcript+form shape logs the transcript reason and *not* the count reason; a two-form session logs the count reason