### PR TITLE
Honour ocr_mode without exception: configured means one call

### DIFF
--- a/app/dashboards/model_assignment_dashboard.rb
+++ b/app/dashboards/model_assignment_dashboard.rb
@@ -31,9 +31,10 @@ class ModelAssignmentDashboard < Administrate::BaseDashboard
     # takes down every resolver call (2026-08-16 incident).
     options: Field::JsonObject.with_options(
       hint: 'JSON object of resolver options, e.g. {} or {"asr_mode": "translate"}. ' \
-            'On an OCR assignment, {"ocr_mode": "extract_and_structure"} fills the form in ONE ' \
-            "vision call and emits no transcript text (~3x cheaper; applies only to a " \
-            "single-output session of 2 pages or fewer on a structuring-capable model)."
+            'On an OCR assignment, {"ocr_mode": "extract_and_structure"} fills each output in ONE ' \
+            "vision call and emits no transcript text (~3x cheaper on a single-output session; " \
+            "with several outputs the document is re-sent per output, which costs more). " \
+            "Needs a model marked able to return schema-valid JSON."
     ),
     created_at: Field::DateTime,
     updated_at: Field::DateTime

--- a/app/services/scribe/orchestrator.rb
+++ b/app/services/scribe/orchestrator.rb
@@ -28,8 +28,6 @@ module Scribe
 
     NOTE_KEY = "note".freeze
 
-    # Combined extraction is for a short report — see #combined_extraction?.
-    MAX_COMBINED_PAGES = 2
     # The "transcript" a combined run structures from: there is none, so say so
     # rather than sending an empty string, which reads as "the document was
     # blank" to a model that is also being handed the document itself.
@@ -244,36 +242,18 @@ module Scribe
     # nil when the session is eligible, else why it is not — in the operator's
     # terms, not the code's.
     def combined_skip_reason
-      outputs = session.scribe_outputs.to_a
-
-      # A transcript output IS the extracted text, which this path never
-      # produces. Checked BEFORE the count: a transcript output costs no
-      # provider call (it echoes the persisted text), so "too many outputs"
-      # would be the wrong diagnosis for the common transcript+form session.
-      if outputs.any? { |o| o.output_type == "transcript" }
-        return "a transcript output was declared, and combined extraction emits no text — " \
-               "drop it to use combined extraction"
-      end
-
-      # Only outputs that actually cost a provider call count: re-sending the
-      # document per output is what makes combining more expensive, not echoes.
-      billable = outputs.reject { |o| o.output_type == "transcript" }
-      return "no output to fill" if billable.empty?
-
-      if billable.size > 1
-        return "#{billable.size} outputs declared — combining re-sends the document per output, " \
-               "which costs more than one extraction feeding them all"
-      end
-
-      unless billable.first.output_type == "form"
-        return "the output is a #{billable.first.output_type}, which has its own result shape; " \
-               "combined extraction fills form outputs only"
-      end
-
-      if session.document_pages > MAX_COMBINED_PAGES
-        return "#{session.document_pages} pages, over the #{MAX_COMBINED_PAGES}-page limit for combined extraction"
-      end
-
+      # Only ONE thing stops a configured mode now: a model that cannot return
+      # schema-valid JSON would produce unusable output, so that falls back to
+      # the two-call path rather than failing the run outright.
+      #
+      # Deliberately NOT checked any more — the operator asked for one call, so
+      # they get one call:
+      #   * a declared transcript output. It resolves to text: null, because
+      #     that is the truth: no text was produced.
+      #   * more than one structured output. Each gets its own combined call,
+      #     which re-sends the document and therefore costs MORE than one
+      #     extraction feeding N cheap text calls. Their trade to make.
+      #   * page count. The output budget is sized per call anyway.
       unless structuring_capable?(ocr_config)
         return "#{ocr_config.api_model_id} is not marked able to return schema-valid JSON " \
                "(needs can_structure, plus supports_json_schema unless it is an Anthropic model)"
@@ -297,25 +277,49 @@ module Scribe
     # Runs the single output through one vision call. Mirrors #call's per-output
     # isolation, metering and rollup so nothing downstream can tell the
     # difference except that the transcript carries no text.
+    # One vision call PER structured output, each reading the document directly.
+    # A single-output session — the case this exists for — is therefore exactly
+    # one provider call. Transcript outputs are echoes and run last, since they
+    # need the stub to exist.
     def call_combined
-      output = session.scribe_outputs.first
-      unless output.status_success?
+      structured, echoes = session.scribe_outputs.partition { |o| o.output_type != "transcript" }
+
+      structured.each do |output|
+        next if output.status_success?
+
         stage = process_combined_output(output)
-        meter_combined(stage) if stage
+        break if stage.nil? # the run failed; do not spend another call
+
+        meter_combined(stage)
       end
+
+      unless transcript_failed?
+        echoes.each do |output|
+          next if output.status_success?
+
+          process_transcript_output(output, session.reload.transcript)
+        end
+      end
+
       finalize_session_status!
       session
     end
 
     def process_combined_output(output)
       stage = combined_stage_for(output)
-      output.result = stage.structured
-      # :partial, not :failure, and result_errors only when there are some —
-      # the column is NOT NULL. Same shape as the split path's form output, so
-      # the rollup and the UI cannot tell which path produced it.
-      if stage.valid
+      # A note output keeps its own { note: ... } contract, as the split path
+      # builds it — the shape is the client's, not this path's business.
+      if output.output_type == NOTE_KEY
+        output.result = { note: (stage.structured || {})[NOTE_KEY] }
+        output.status = :success
+      elsif stage.valid
+        output.result = stage.structured
         output.status = :success
       else
+        # :partial, not :failure, and result_errors only when there are some —
+        # the column is NOT NULL. Same shape as the split path's form output, so
+        # the rollup and the UI cannot tell which path produced it.
+        output.result = stage.structured
         output.status = :partial
         output.result_errors = stage.errors
       end
@@ -338,7 +342,10 @@ module Scribe
     end
 
     def combined_stage_for(output)
-      if output.inline_fields.present?
+      if output.output_type == NOTE_KEY
+        fields = [ note_field ]
+        system_prompt = output.template_ref.presence || output.page&.prompt
+      elsif output.inline_fields.present?
         fields = Scribe::InlineField.build_all(output.inline_fields)
         system_prompt = nil
       else

--- a/docs/api/v2.md
+++ b/docs/api/v2.md
@@ -207,19 +207,17 @@ order and sequentially* — a report photographed a page at a time is transcribe
 in upload order. Racing the calls is safe but shuffles the pages.
 
 At commit, a vision model extracts the complete document text in a single call
-across every attached file. **Combined extraction.** An operator can instead set `ocr_mode` to
-`"extract_and_structure"` on the account's OCR model assignment, which fills the
-declared form in ONE call and emits no text — the session's `transcript.text` is
-then `null`. It is used only when ALL of these hold, and silently falls back to
-the two-call path otherwise: the session declares exactly one output, that
-output is a `form`, the session is 2 pages or fewer, and the assigned model —
-and its fallback — can return schema-valid JSON. So handle `transcript.text:
-null` whenever your operator may have enabled it. That text is persisted as the session's
-`transcript` — the audit trail of what the model actually read — and the
-declared outputs are then structured from it exactly as for audio. An
-extraction that hits the model's output budget is a **failure**, never a
-truncated transcript: a partial lab report that reads as complete is worse than
-no result. Re-commit to retry it.
+across every attached file.
+
+**Combined extraction.** An operator can set `ocr_mode` to
+`"extract_and_structure"` on the account's OCR model assignment. Each declared
+output is then filled by ONE vision call that reads the document directly, and
+no text is extracted — so `transcript.text` is `null`, and a declared
+`transcript` output resolves to `{ "text": null }`. A single-output session is
+therefore exactly one provider call. With more than one structured output the
+document is re-sent per output, which costs MORE than one extraction feeding
+them all. The only case that falls back to the two-call path is a model not
+marked able to return schema-valid JSON; it is logged with the reason.
 
 **Responses**
 

--- a/test/integration/api/v2/combined_extraction_test.rb
+++ b/test/integration/api/v2/combined_extraction_test.rb
@@ -106,28 +106,25 @@ module Api
 
       # ── the gates: each falls back to the two-call path, never a 4xx ──────
 
-      test "a declared transcript output keeps the two-call path" do
+      test "a declared transcript output still runs combined, and its text is null" do
         assign_combined_ocr!
-        # OCR text, then structuring JSON — two calls.
-        stub_request(:post, CHAT_URL).to_return(
-          { status: 200, headers: { "Content-Type" => "application/json" },
-            body: { choices: [ { message: { content: "Hemoglobin 13.5" }, finish_reason: "stop" } ],
-                    usage: { prompt_tokens: 900, completion_tokens: 100 } }.to_json },
-          { status: 200, headers: { "Content-Type" => "application/json" },
-            body: { choices: [ { message: { content: { hemoglobin: "13.5" }.to_json }, finish_reason: "stop" } ],
-                    usage: { prompt_tokens: 200, completion_tokens: 20 } }.to_json }
-        )
+        stub_structured
         id = document_session(outputs: [ { type: "transcript" }, { type: "form", page_id: nil } ])
 
         post "/api/v2/scribe_sessions/#{id}/commit", headers: @headers
 
         session = ScribeSession.find(id)
         assert_equal "completed", session.status
-        assert_includes session.transcript.text, "Hemoglobin", "the text must still exist"
-        assert_requested :post, CHAT_URL, times: 2
+        # One structured output = ONE call. The transcript output is an echo of
+        # the stub, so it reports the truth: no text was produced.
+        assert_requested :post, CHAT_URL, times: 1
+        assert_nil session.transcript.text
+        echo = session.scribe_outputs.find { |o| o.output_type == "transcript" }
+        assert_equal "success", echo.status
+        assert_nil echo.result["text"]
       end
 
-      test "more than one output keeps the two-call path" do
+      test "two form outputs each get their own combined call" do
         assign_combined_ocr!
         second = create(:page, template: @page.template)
         create(:form_field, page: second, title: "wbc", friendly_name: "WBC", field_type: "string")
@@ -141,26 +138,28 @@ module Api
 
         post "/api/v2/scribe_sessions/#{id}/commit", headers: @headers
 
-        # The split path: an extracted transcript exists, and there was more
-        # than one call. Not pinned to an exact count — a schema-repair re-ask
-        # legitimately adds one and is not what this test is about.
-        assert_not_nil ScribeSession.find(id).transcript.text
-        assert_requested :post, CHAT_URL, at_least_times: 3
+        # One combined call per structured output — which costs MORE than one
+        # extraction feeding two cheap text calls. The operator asked for it.
+        # Pinned on the usage events rather than the raw request count, which a
+        # schema-repair re-ask legitimately inflates.
+        assert_equal 2, UsageEvent.where(scribe_session_id: id, function: "ocr").count
+        assert_equal 0, UsageEvent.where(scribe_session_id: id, function: "structuring").count
+        assert_nil ScribeSession.find(id).transcript.text
       end
 
-      test "a report longer than the page limit keeps the two-call path" do
+      test "a longer report still runs combined" do
         assign_combined_ocr!
         stub_request(:post, CHAT_URL).to_return(
           status: 200, headers: { "Content-Type" => "application/json" },
           body: { choices: [ { message: { content: { hemoglobin: "13.5" }.to_json }, finish_reason: "stop" } ],
                   usage: { prompt_tokens: 900, completion_tokens: 100 } }.to_json
         )
-        id = document_session(pages: Scribe::Orchestrator::MAX_COMBINED_PAGES + 1)
+        id = document_session(pages: 5)
 
         post "/api/v2/scribe_sessions/#{id}/commit", headers: @headers
 
-        assert_requested :post, CHAT_URL, times: 2
-        assert_not_nil ScribeSession.find(id).transcript.text
+        assert_requested :post, CHAT_URL, times: 1
+        assert_nil ScribeSession.find(id).transcript.text
       end
 
       test "a model that cannot return structured JSON keeps the two-call path" do
@@ -213,7 +212,7 @@ module Api
 
       # A note output has its own field, prompt and { note: ... } result shape;
       # the combined path would return a form-shaped result.
-      test "a note output keeps the two-call path" do
+      test "a note output runs combined and keeps its own result shape" do
         assign_combined_ocr!
         stub_request(:post, CHAT_URL).to_return(
           status: 200, headers: { "Content-Type" => "application/json" },
@@ -225,7 +224,8 @@ module Api
         post "/api/v2/scribe_sessions/#{id}/commit", headers: @headers
 
         session = ScribeSession.find(id)
-        assert_not_nil session.transcript.text
+        assert_requested :post, CHAT_URL, times: 1
+        assert_nil session.transcript.text
         assert_equal "text", session.scribe_outputs.sole.result["note"]
       end
 
@@ -252,43 +252,23 @@ module Api
       # Production, 2026-08-17: ocr_mode was set and every session still took
       # the two-call path, with no signal anywhere as to why. The operator has
       # to be able to find out.
-      test "skipping a configured combined run says which guard refused" do
-        assign_combined_ocr!
+      test "skipping for an incapable model says so" do
+        assign_combined_ocr!(capabilities: { "supports_vision" => true, "supports_pdf" => true })
         stub_request(:post, CHAT_URL).to_return(
           status: 200, headers: { "Content-Type" => "application/json" },
           body: { choices: [ { message: { content: { hemoglobin: "13.5" }.to_json }, finish_reason: "stop" } ],
                   usage: { prompt_tokens: 900, completion_tokens: 100 } }.to_json
         )
-        id = document_session(outputs: [ { type: "transcript" }, { type: "form", page_id: nil } ])
+        id = document_session
 
         logged = capture_orchestrator_log do
           post "/api/v2/scribe_sessions/#{id}/commit", headers: @headers
         end
 
         assert_match(/combined extraction skipped for session=#{id}/, logged)
-        # The RIGHT reason: a transcript output costs no provider call, so
-        # "too many outputs" would be a misleading diagnosis for this shape.
-        assert_match(/transcript output was declared/, logged)
-        assert_no_match(/2 outputs declared/, logged)
+        assert_match(/schema-valid JSON/, logged)
       end
 
-      test "a two-form session is refused for the cost reason, not the transcript one" do
-        assign_combined_ocr!
-        second = create(:page, template: @page.template)
-        create(:form_field, page: second, title: "wbc", friendly_name: "WBC", field_type: "string")
-        stub_request(:post, CHAT_URL).to_return(
-          status: 200, headers: { "Content-Type" => "application/json" },
-          body: { choices: [ { message: { content: { hemoglobin: "13.5" }.to_json }, finish_reason: "stop" } ],
-                  usage: { prompt_tokens: 900, completion_tokens: 100 } }.to_json
-        )
-        id = document_session(outputs: [ { type: "form", page_id: @page.id },
-                                         { type: "form", page_id: second.id } ])
-
-        logged = capture_orchestrator_log do
-          post "/api/v2/scribe_sessions/#{id}/commit", headers: @headers
-        end
-        assert_match(/2 outputs declared/, logged)
-      end
 
       # ── failure ──────────────────────────────────────────────────────────
 


### PR DESCRIPTION
`ocr_mode: "extract_and_structure"` was set in production and every session still took the two-call path. The mode was built as a *permission* with four guards; that is not what the setting says, and the guards were making a cost/shape judgement that belongs to the operator.

**Configured now means used.** Removed:

- **transcript output** — it now resolves to `{"text": null}`, which is the truth: no text was produced
- **single output** — each structured output gets its own combined call. One output = exactly one call. Several cost **more** than one extraction feeding them all; that is the operator's trade to make, and the docs say so
- **page cap** — the output budget is sized per call anyway
- **form-only** — a note output keeps its own `{ note: ... }` contract

**One guard remains:** a model not marked able to return schema-valid JSON would produce unusable output, so it falls back to the two-call path rather than failing the run — and logs the reason.

## Test plan
- [x] `bin/rails test` — 650 runs, 0 failures
- [x] rubocop + brakeman clean
- [x] Tests rewritten to the new behaviour: transcript+form is ONE call with a null-text echo; two form outputs produce two `:ocr` events and zero `:structuring`; a 5-page report still combines; a note output combines and keeps its shape; only the incapable-model case still falls back