### PR TITLE
Allow fields to accept null values in schema and update tests accordingly

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,3 +16,4 @@ Rails/RefuteMethods:
     - "test/services/llm/adapters/anthropic_adapter_test.rb"
     - "test/services/scribe/stages_test.rb"
     - "test/services/scribe/schema_validator_test.rb"
+    - "test/services/scribe/schema_builder_test.rb"

--- a/app/services/scribe/schema_builder.rb
+++ b/app/services/scribe/schema_builder.rb
@@ -42,11 +42,15 @@ module Scribe
     private
 
     def field_schema(field, for_validation: false)
-      schema = { type: json_type(field), description: description_for(field) }
+      # Every field is optional (see `call` above) — the type must honestly
+      # allow `null` too, not just key absence, since some providers/modes
+      # return an explicit `null` for a field with no data instead of
+      # omitting the key.
+      schema = { type: [ json_type(field), "null" ], description: description_for(field) }
 
       case field.field_type.to_s
       when "single_select"
-        schema[:enum] = Array(field.enum_options) if present?(field.enum_options)
+        schema[:enum] = Array(field.enum_options) + [ nil ] if present?(field.enum_options)
       when "multi_select"
         items = { type: "string" }
         items[:enum] = Array(field.enum_options) if present?(field.enum_options)

--- a/app/services/scribe/schema_builder.rb
+++ b/app/services/scribe/schema_builder.rb
@@ -50,7 +50,7 @@ module Scribe
 
       case field.field_type.to_s
       when "single_select"
-        schema[:enum] = Array(field.enum_options) + [ nil ] if present?(field.enum_options)
+        schema[:enum] = (Array(field.enum_options) + [ nil ]).uniq if present?(field.enum_options)
       when "multi_select"
         items = { type: "string" }
         items[:enum] = Array(field.enum_options) if present?(field.enum_options)

--- a/app/services/scribe/schema_builder.rb
+++ b/app/services/scribe/schema_builder.rb
@@ -42,10 +42,8 @@ module Scribe
     private
 
     def field_schema(field, for_validation: false)
-      # Every field is optional (see `call` above) — the type must honestly
-      # allow `null` too, not just key absence, since some providers/modes
-      # return an explicit `null` for a field with no data instead of
-      # omitting the key.
+      # Every field is optional, and strict decoders spell "absent" as an
+      # explicit null rather than by omitting the key.
       schema = { type: [ json_type(field), "null" ], description: description_for(field) }
 
       case field.field_type.to_s

--- a/bruno/environments/Local.bru
+++ b/bruno/environments/Local.bru
@@ -1,8 +1,8 @@
 vars {
-  baseUrl: http://localhost:3000
-  apiToken:
-  sessionId:
-  sessionToken:
+  baseUrl: https://medispeak-backend-kxq9k.ondigitalocean.app
+  apiToken: msk_live_65219eed6ece390a56b38c207e70fe4f8be4d79b
+  sessionId: 
+  sessionToken: 
 }
 vars:secret [
   apiToken

--- a/test/services/scribe/inline_field_test.rb
+++ b/test/services/scribe/inline_field_test.rb
@@ -14,8 +14,8 @@ class Scribe::InlineFieldTest < ActiveSupport::TestCase
       { "key" => "sx", "label" => "Symptoms", "type" => "multi_select", "enum" => %w[fever cough] }
     ])
     schema = Scribe::SchemaBuilder.new(fields: fields).call
-    assert_equal "number", schema[:properties]["hr"][:type]
-    assert_equal "array", schema[:properties]["sx"][:type]
+    assert_equal [ "number", "null" ], schema[:properties]["hr"][:type]
+    assert_equal [ "array", "null" ], schema[:properties]["sx"][:type]
     assert_equal %w[fever cough], schema[:properties]["sx"][:items][:enum]
   end
 

--- a/test/services/scribe/schema_builder_test.rb
+++ b/test/services/scribe/schema_builder_test.rb
@@ -1,6 +1,7 @@
 # Standalone unit tests for Scribe::SchemaBuilder.
 # Runnable without Rails/DB: `ruby -Itest test/services/scribe/schema_builder_test.rb`
 require "minitest/autorun"
+require "json_schemer"
 
 # Standalone mode loads the file directly; under `bin/rails test` Zeitwerk
 # autoloads Scribe::SchemaBuilder, so skip the manual load.
@@ -77,6 +78,35 @@ class SchemaBuilderTest < Minitest::Test
     schema = build([ Field.new(title: "x", friendly_name: "Friendly",
                               description: "Explicit help", field_type: "string") ])
     assert_equal "Explicit help", schema[:properties]["x"][:description]
+  end
+
+  # The point of the nullable types above, stated as behaviour rather than
+  # shape. A single_select carries BOTH `type` and `enum`, and a value must
+  # satisfy both — so leaving null out of the enum makes the enum the tighter
+  # constraint and forbids null no matter how nullable the type is. A strict
+  # decoding engine then cannot answer "not mentioned in the transcript": it is
+  # forced to pick one of the options, inventing a clinical value rather than
+  # omitting one. Assert against a real validator so a regression cannot hide
+  # behind a passing shape assertion.
+  def test_a_single_select_can_actually_be_null
+    prop = build([ Field.new(title: "sev", friendly_name: "Severity",
+                             field_type: "single_select", enum_options: %w[low high]) ])[:properties]["sev"]
+    schemer = JSONSchemer.schema(JSON.parse({ type: "object", properties: { sev: prop }, required: [] }.to_json))
+
+    assert schemer.valid?({ "sev" => nil }), "a single_select must be able to abstain"
+    assert schemer.valid?({ "sev" => "low" }), "a real option must still validate"
+    refute schemer.valid?({ "sev" => "medium" }), "the enum must still reject values outside it"
+  end
+
+  def test_a_multi_select_can_be_null_without_loosening_its_item_enum
+    prop = build([ Field.new(title: "sx", friendly_name: "Symptoms",
+                             field_type: "multi_select", enum_options: %w[cough fever]) ])[:properties]["sx"]
+    schemer = JSONSchemer.schema(JSON.parse({ type: "object", properties: { sx: prop }, required: [] }.to_json))
+
+    assert schemer.valid?({ "sx" => nil }), "the array itself may be absent"
+    assert schemer.valid?({ "sx" => [] }), "an empty selection is legitimate"
+    refute schemer.valid?({ "sx" => [ nil ] }), "null is NOT a valid member of the list"
+    refute schemer.valid?({ "sx" => [ "sneeze" ] }), "items must still come from the enum"
   end
 
   def test_object_envelope

--- a/test/services/scribe/schema_builder_test.rb
+++ b/test/services/scribe/schema_builder_test.rb
@@ -20,7 +20,7 @@ class SchemaBuilderTest < Minitest::Test
   def test_string_field
     schema = build([ Field.new(title: "name", friendly_name: "Name", field_type: "string") ])
     prop = schema[:properties]["name"]
-    assert_equal "string", prop[:type]
+    assert_equal [ "string", "null" ], prop[:type]
     assert_equal "Name", prop[:description]
   end
 
@@ -29,16 +29,16 @@ class SchemaBuilderTest < Minitest::Test
       Field.new(title: "smoker", friendly_name: "Smoker", field_type: "boolean"),
       Field.new(title: "age", friendly_name: "Age", field_type: "number")
     ])
-    assert_equal "boolean", schema[:properties]["smoker"][:type]
-    assert_equal "number", schema[:properties]["age"][:type]
+    assert_equal [ "boolean", "null" ], schema[:properties]["smoker"][:type]
+    assert_equal [ "number", "null" ], schema[:properties]["age"][:type]
   end
 
   def test_single_select_emits_enum_on_string
     schema = build([ Field.new(title: "sev", friendly_name: "Severity",
                               field_type: "single_select", enum_options: %w[low high]) ])
     prop = schema[:properties]["sev"]
-    assert_equal "string", prop[:type]
-    assert_equal %w[low high], prop[:enum]
+    assert_equal [ "string", "null" ], prop[:type]
+    assert_equal [ "low", "high", nil ], prop[:enum]
   end
 
   # The bug being fixed: multi_select must put enum on items, not the array.
@@ -46,7 +46,7 @@ class SchemaBuilderTest < Minitest::Test
     schema = build([ Field.new(title: "symptoms", friendly_name: "Symptoms",
                               field_type: "multi_select", enum_options: %w[cough fever]) ])
     prop = schema[:properties]["symptoms"]
-    assert_equal "array", prop[:type]
+    assert_equal [ "array", "null" ], prop[:type]
     assert_nil prop[:enum], "enum must NOT be on the array itself"
     assert_equal({ type: "string", enum: %w[cough fever] }, prop[:items])
   end

--- a/test/services/scribe/schema_builder_test.rb
+++ b/test/services/scribe/schema_builder_test.rb
@@ -41,6 +41,12 @@ class SchemaBuilderTest < Minitest::Test
     assert_equal [ "low", "high", nil ], prop[:enum]
   end
 
+  def test_single_select_enum_dedupes_when_options_already_include_nil
+    schema = build([ Field.new(title: "sev", friendly_name: "Severity",
+                              field_type: "single_select", enum_options: [ "low", "high", nil ]) ])
+    assert_equal [ "low", "high", nil ], schema[:properties]["sev"][:enum]
+  end
+
   # The bug being fixed: multi_select must put enum on items, not the array.
   def test_multi_select_emits_items_enum_not_array_enum
     schema = build([ Field.new(title: "symptoms", friendly_name: "Symptoms",

--- a/test/services/scribe/schema_builder_test.rb
+++ b/test/services/scribe/schema_builder_test.rb
@@ -80,14 +80,8 @@ class SchemaBuilderTest < Minitest::Test
     assert_equal "Explicit help", schema[:properties]["x"][:description]
   end
 
-  # The point of the nullable types above, stated as behaviour rather than
-  # shape. A single_select carries BOTH `type` and `enum`, and a value must
-  # satisfy both — so leaving null out of the enum makes the enum the tighter
-  # constraint and forbids null no matter how nullable the type is. A strict
-  # decoding engine then cannot answer "not mentioned in the transcript": it is
-  # forced to pick one of the options, inventing a clinical value rather than
-  # omitting one. Assert against a real validator so a regression cannot hide
-  # behind a passing shape assertion.
+  # enum and type must BOTH be satisfied, so a nullable type with null missing
+  # from the enum still forbids null — and the model must invent a value.
   def test_a_single_select_can_actually_be_null
     prop = build([ Field.new(title: "sev", friendly_name: "Severity",
                              field_type: "single_select", enum_options: %w[low high]) ])[:properties]["sev"]


### PR DESCRIPTION
<img width="1033" height="841" alt="image" src="https://github.com/user-attachments/assets/00aff9df-80e6-4fae-ad90-4e941d4cc4af" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated generated schemas to correctly allow empty (`null`) values across supported field types.
  * Single-select fields now accept no selection, while multi-select fields remain validated as arrays with their available options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->