### PR TITLE
Enhance schema validation

### DIFF
--- a/app/services/scribe/schema_validator.rb
+++ b/app/services/scribe/schema_validator.rb
@@ -61,13 +61,26 @@ module Scribe
         begin
           JSON.parse(trimmed)
         rescue JSON::ParserError
+          pointer = "/#{escape_pointer_token(key)}"
           errs << {
-            pointer: "/#{key}",
+            pointer: pointer,
             type: "malformed_json_string",
-            message: "value at /#{key} looks like malformed or truncated JSON"
+            # Spelled out for the repair re-ask, which only ever sees these
+            # messages: name both failure modes so the model knows what to do.
+            message: "value at `#{pointer}` is a JSON payload that does not " \
+                     "parse (truncated or over-escaped); re-send it complete " \
+                     "and escaped exactly once"
           }
         end
       end
+    end
+
+    # Field titles are free text and really do contain "/" ("Procedure /
+    # Surgery Planned"), so hand-built pointers need the same RFC 6901 escaping
+    # json_schemer applies — otherwise the two error sources disagree about how
+    # to name the same field. "~" first, or it would double-escape the "~1".
+    def escape_pointer_token(key)
+      key.to_s.gsub("~", "~0").gsub("/", "~1")
     end
 
     # A leading [ or { alone also matches plain-text answers like
@@ -88,7 +101,21 @@ module Scribe
     # Round-trip through JSON so symbol-keyed Ruby hashes become string-keyed,
     # which is what JSON Schema validation expects.
     def normalize(data)
-      JSON.parse(data.is_a?(String) ? data : JSON.generate(data))
+      drop_nulls(JSON.parse(data.is_a?(String) ? data : JSON.generate(data)))
+    end
+
+    # Every field is optional (SchemaBuilder emits `required: []`), but OpenAI
+    # strict mode cannot express that — the adapter has to mark every key
+    # required and nullable, so the model spells "not mentioned in the
+    # transcript" as an explicit null. Validating those against the core
+    # schema's non-nullable "string"/"number" made the validator reject the
+    # exact shape we asked the model for: it accounted for essentially every
+    # structuring error in production, and each one burned a repair re-ask that
+    # could only ever come back null again. Treat null as absent instead.
+    def drop_nulls(data)
+      return data unless data.is_a?(Hash)
+
+      data.reject { |_, value| value.nil? }
     end
   end
 end

--- a/app/services/scribe/schema_validator.rb
+++ b/app/services/scribe/schema_validator.rb
@@ -11,11 +11,13 @@ module Scribe
     end
 
     def valid?(data)
-      @schemer.valid?(normalize(data))
+      errors(data).empty?
     end
 
     def errors(data)
-      @schemer.validate(normalize(data)).map { |e| format_error(e) }
+      normalized = normalize(data)
+      @schemer.validate(normalized).map { |e| format_error(e) } +
+        malformed_json_string_errors(normalized)
     end
 
     # Returns [data, []] when valid. When invalid and a block is given, calls the
@@ -38,6 +40,41 @@ module Scribe
         type: err["type"],
         message: err["error"] || "#{err['data_pointer']} failed #{err['type']} validation"
       }
+    end
+
+    # Callers embed nested structured sub-data (medication, diagnosis, …) as a
+    # JSON-encoded string inside an otherwise plain "string" field — a shape
+    # the JSON Schema itself can't constrain. A reasoning model occasionally
+    # leaks scratchpad text after (or instead of) the real JSON there, which
+    # is schema-valid (still a string) but unusable. Treat a value that looks
+    # like JSON but doesn't fully parse as a validation failure so it goes
+    # through the same bounded repair re-ask as any other error.
+    def malformed_json_string_errors(data)
+      return [] unless data.is_a?(Hash)
+
+      data.each_with_object([]) do |(key, value), errs|
+        next unless value.is_a?(String)
+
+        trimmed = value.strip
+        next unless looks_like_json_payload?(trimmed)
+
+        begin
+          JSON.parse(trimmed)
+        rescue JSON::ParserError
+          errs << {
+            pointer: "/#{key}",
+            type: "malformed_json_string",
+            message: "value at /#{key} looks like malformed or truncated JSON"
+          }
+        end
+      end
+    end
+
+    # A leading [ or { alone also matches plain-text answers like
+    # "[not mentioned]" or "{pending}" — require an actual "key": shape too,
+    # so only a real (but broken) object/array payload is flagged.
+    def looks_like_json_payload?(text)
+      text.start_with?("[", "{") && text.include?('":')
     end
 
     def deep_stringify(obj)

--- a/test/services/scribe/schema_validator_test.rb
+++ b/test/services/scribe/schema_validator_test.rb
@@ -90,4 +90,52 @@ class SchemaValidatorTest < Minitest::Test
     assert validator.valid?({ "notes" => "[not mentioned]" })
     assert validator.valid?({ "notes" => "{pending}" })
   end
+
+  # Observed in production: the payload is escaped a second time, so the string
+  # holds literal backslash-quote and never parses.
+  def test_rejects_double_escaped_json_string
+    refute validator.valid?({ "notes" => '[{\"medicine\":{\"code\":\"\"}}]' })
+  end
+
+  # Truncated mid-payload — the model ran out of room.
+  def test_rejects_truncated_json_string
+    refute validator.valid?({ "notes" => '[{"medicine":{"code":"386661006","display' })
+  end
+
+  # Every field is optional, and OpenAI strict mode makes the model spell
+  # "not mentioned" as an explicit null. Rejecting that was the single largest
+  # source of structuring errors in production.
+  def test_null_is_treated_as_absent_not_as_a_type_error
+    assert validator.valid?({ "age" => nil, "severity" => nil, "symptoms" => nil })
+    assert_empty validator.errors({ "age" => nil })
+  end
+
+  def test_null_does_not_trigger_a_repair_re_ask
+    invoked = 0
+    data, errs = validator.validate_and_repair({ "severity" => nil }) { |_| invoked += 1; {} }
+    assert_equal 0, invoked
+    assert_empty errs
+    assert_equal({ "severity" => nil }, data)
+  end
+
+  # Dropping nulls is a validation-time concern only: the caller still persists
+  # the model's payload verbatim, nulls included.
+  def test_null_survives_into_the_returned_data
+    data, = validator.validate_and_repair({ "age" => 30, "severity" => nil })
+    assert_equal({ "age" => 30, "severity" => nil }, data)
+  end
+
+  # A null must not become an escape hatch past a real constraint on a
+  # non-null sibling.
+  def test_null_alongside_an_invalid_value_still_reports_that_value
+    refute validator.valid?({ "severity" => nil, "age" => 200 })
+  end
+
+  # Field titles are free text, so the pointer needs RFC 6901 escaping to match
+  # the pointers json_schemer produces for the same field.
+  def test_malformed_json_pointer_is_rfc6901_escaped
+    errs = validator.errors({ "Procedure / Surgery" => '[{"code":' })
+    err = errs.find { |e| e[:type] == "malformed_json_string" }
+    assert_equal "/Procedure ~1 Surgery", err[:pointer]
+  end
 end

--- a/test/services/scribe/schema_validator_test.rb
+++ b/test/services/scribe/schema_validator_test.rb
@@ -66,4 +66,28 @@ class SchemaValidatorTest < Minitest::Test
     assert_equal 0, invoked
     assert_empty errs
   end
+
+  # Reasoning-model leak: a string field holding JSON-encoded nested data
+  # (e.g. a medication array) with trailing scratchpad text appended after it.
+  def test_rejects_json_looking_string_with_trailing_garbage
+    leaked = '[{"medicine":{"code":""}}] However I am not sure about the last character.'
+    refute validator.valid?({ "notes" => leaked })
+    errs = validator.errors({ "notes" => leaked })
+    assert(errs.any? { |e| e[:type] == "malformed_json_string" })
+  end
+
+  def test_accepts_well_formed_json_string
+    assert validator.valid?({ "notes" => '[{"medicine":{"code":""}}]' })
+  end
+
+  def test_plain_prose_string_is_not_flagged_as_malformed_json
+    assert validator.valid?({ "notes" => "low" })
+  end
+
+  # A plain-text answer that happens to be bracket-wrapped (a stylistic
+  # annotation, not a leaked structured payload) must not be flagged.
+  def test_bracketed_plain_text_is_not_flagged_as_malformed_json
+    assert validator.valid?({ "notes" => "[not mentioned]" })
+    assert validator.valid?({ "notes" => "{pending}" })
+  end
 end


### PR DESCRIPTION
Enhance schema validation to reject malformed JSON strings and add corresponding tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of structured data embedded in text fields.
  * More accurately reports malformed or truncated JSON-like content, including escaped field locations.
  * Preserves valid null values while correctly handling optional fields during validation and repair.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->