### PR TITLE
Add read-only admin impersonation ("view as user")

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,9 @@ gem "ruby-openai", "~> 6.2"
 gem "pagy", "~> 6.0"
 # Pundit for authorization
 gem "pundit", "~> 2.4"
+# Admin "view as user" support. Overrides current_user without touching the
+# Warden session, so the admin's own login survives the impersonation.
+gem "pretender", "~> 1.0"
 # AWS S3 for file storage
 gem "aws-sdk-s3", require: false
 # Devise for authentication

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -303,6 +303,8 @@ GEM
     pg (1.5.9)
     pp (0.6.4)
       prettyprint
+    pretender (1.0.0)
+      actionpack (>= 7.2)
     prettyprint (0.2.0)
     prism (1.9.0)
     propshaft (1.1.0)
@@ -527,6 +529,7 @@ DEPENDENCIES
   pagy (~> 6.0)
   pdf-reader (~> 2.12)
   pg (~> 1.1)
+  pretender (~> 1.0)
   propshaft
   pry
   puma (>= 5.0)

--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -6,8 +6,18 @@
 # you're free to overwrite the RESTful controller actions.
 module Admin
   class ApplicationController < Administrate::ApplicationController
+    # Repeated from ::ApplicationController on purpose: Administrate's base
+    # class descends from ActionController::Base, so this namespace inherits
+    # none of the app's overrides. Without it, current_user here would stay the
+    # real admin and /admin would remain open during an impersonation — the one
+    # failure that would look like it worked.
+    impersonates :user
+
     before_action :authenticate_admin
 
+    # authenticate_user! is Warden's and still sees the real admin (pretender
+    # never touches the session), so the admin stays logged in; it is admin?
+    # going false on the impersonated current_user that closes this namespace.
     def authenticate_admin
       authenticate_user!
       redirect_to root_path, alert: "Not authorized." unless current_user.admin?

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,5 +1,23 @@
 module Admin
   class UsersController < Admin::ApplicationController
+    # Start viewing the app as this user. The redirect leaves /admin because
+    # this request is the last one that still has admin powers — from the next
+    # one on, current_user is the target and authenticate_admin turns us away.
+    def impersonate
+      target = User.find(params[:id])
+
+      # Privileges follow the impersonated identity, so impersonating another
+      # admin would hand straight back the powers this feature exists to drop —
+      # and with them the ability to write, defeating the read-only guard.
+      if target.admin?
+        return redirect_to admin_user_path(target),
+                           alert: "Cannot view as another admin."
+      end
+
+      impersonate_user(target)
+      redirect_to root_path, notice: "Now viewing as #{target.email}."
+    end
+
     # Overwrite any of the RESTful controller actions to implement custom behavior
     # For example, you may want to send an email after a foo is updated.
     #

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,17 @@ class ApplicationController < ActionController::Base
   # maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
 
+  # Admin "view as user". current_user becomes the impersonated user, so every
+  # tenant-scoped surface follows without changes: current_account and
+  # pundit_user below already hang off it, and User#admin? goes false, which is
+  # what closes /admin for the duration.
+  #
+  # This is declared again in Admin::ApplicationController — Administrate's base
+  # class descends from ActionController::Base, NOT from this class, so it does
+  # not inherit the override. Without both, /admin would keep seeing the real
+  # admin and stay open mid-impersonation.
+  impersonates :user
+
   # The UI is private by default: every controller requires a signed-in user
   # and an explicit authorization call. A surface that should be public opts
   # out deliberately rather than by omission.
@@ -19,6 +30,7 @@ class ApplicationController < ActionController::Base
   # when those name an action a subclass does not define — and singular-resource
   # controllers (usage, account) legitimately have no :index.
   before_action :authenticate_user!, unless: :devise_controller?
+  before_action :enforce_read_only_while_impersonating
   after_action :verify_authorized, unless: -> { devise_controller? || action_name == "index" }
   after_action :verify_policy_scoped, if: -> { !devise_controller? && action_name == "index" }
 
@@ -28,7 +40,27 @@ class ApplicationController < ActionController::Base
     current_user
   end
 
+  # Compared against true_user rather than reading pretender's session key, so
+  # this keeps working if the gem renames it.
+  def impersonating?
+    current_user.present? && current_user != true_user
+  end
+  helper_method :impersonating?
+
   private
+
+  # Impersonation is a viewing tool: the admin sees the tenant's data but never
+  # acts as them. A blanket verb check is the whole enforcement — policies stay
+  # untouched, so there is no per-policy rule to remember on the next feature.
+  # Anything that legitimately writes while impersonating (only the exit route
+  # today) skips this callback explicitly.
+  def enforce_read_only_while_impersonating
+    return unless impersonating?
+    return if request.get? || request.head?
+
+    redirect_back fallback_location: root_path,
+                  alert: "You are viewing as #{current_user.email} — this is read-only."
+  end
 
   # Pundit denials are a redirect, not a 500. Three controllers previously
   # declared `rescue_from ..., with: :user_not_authorized` without defining the

--- a/app/controllers/impersonations_controller.rb
+++ b/app/controllers/impersonations_controller.rb
@@ -1,0 +1,21 @@
+# Ending an impersonation. Deliberately NOT under /admin: admin? is false for
+# the duration, so that namespace is closed to the very person who needs to get
+# out of it. This is the one door that has to stay on the outside.
+class ImpersonationsController < ApplicationController
+  # DELETE is a write, and the read-only guard blocks writes while
+  # impersonating — which would make the exit unreachable.
+  skip_before_action :enforce_read_only_while_impersonating
+
+  # There is no record to authorize here: the action's whole effect is on the
+  # requester's own session, and the guard below is the authorization.
+  skip_after_action :verify_authorized
+
+  def destroy
+    return redirect_to root_path unless impersonating?
+
+    was = current_user
+    stop_impersonating_user
+    # Back to where the admin started, rather than to a generic admin root.
+    redirect_to admin_user_path(was), notice: "Stopped viewing as #{was.email}."
+  end
+end

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,0 +1,17 @@
+<%#
+Adds a "View as user" button to Administrate's stock show page.
+
+Rendering the gem's own template rather than copying it keeps this to the one
+thing we're adding — :header_last is the hook it provides for exactly this.
+%>
+
+<% unless page.resource.admin? %>
+  <% content_for(:header_last) do %>
+    <%= button_to "View as user",
+                  impersonate_admin_user_path(page.resource),
+                  class: "button",
+                  data: { turbo_confirm: "View the app as #{page.resource.email}? You will be read-only until you stop." } %>
+  <% end %>
+<% end %>
+
+<%= render template: "administrate/application/show", locals: { page: page } %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -34,6 +34,7 @@
   <body class="h-full font-sans antialiased font-normal leading-normal bg-gray-50">
     <div class="main flex flex-col">
       <header>
+        <%= render partial: "shared/impersonation_banner" %>
         <%= render partial: "shared/flash" %>
         <%= render partial: "shared/navbar" %>
       </header>

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -1,4 +1,6 @@
-<div id="flash" class="fixed top-4 right-4 z-50 max-w-md" data-controller="flash">
+<%# Drops below the impersonation banner when one is showing, so the toast and
+    the "stop viewing as user" control never cover each other. %>
+<div id="flash" class="fixed <%= impersonating? ? "top-16" : "top-4" %> right-4 z-50 max-w-md" data-controller="flash">
   <% if notice %>
     <div class="notice bg-blue-100 border-l-4 border-blue-500 text-blue-700 p-4 mb-4 rounded shadow-md" role="alert">
       <div class="flex items-center">

--- a/app/views/shared/_impersonation_banner.html.erb
+++ b/app/views/shared/_impersonation_banner.html.erb
@@ -1,0 +1,19 @@
+<%# Persistent while impersonating: the whole point is that the admin can never
+    forget whose data is on screen, so this sits above the nav on every page. %>
+<% if impersonating? %>
+  <%# Sticky and above the flash's z-50: the exit is the safety valve, so it
+      must stay reachable without scrolling and must never be painted over.
+      The flash offsets itself downward to match — see shared/_flash. %>
+  <div class="bg-amber-500 text-amber-950 sticky top-0 z-[60]" role="status">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-2 flex flex-wrap items-center justify-between gap-2">
+      <p class="text-sm font-medium">
+        Viewing as <span class="font-semibold"><%= current_user.email %></span>
+        &middot; read-only &middot; signed in as <%= true_user.email %>
+      </p>
+      <%= button_to "Stop viewing as user",
+                    impersonation_path,
+                    method: :delete,
+                    class: "text-sm font-semibold underline underline-offset-2 hover:no-underline" %>
+    </div>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,11 @@ Rails.application.routes.draw do
   # every day-to-day surface lives in the first-class UI below. Gated by
   # Admin::ApplicationController on User#admin?.
   namespace :admin do
-    resources :users
+    resources :users do
+      # Starting is an admin power, so it lives here. Stopping cannot — see the
+      # top-level :impersonation route below.
+      post :impersonate, on: :member
+    end
     resources :accounts
     resources :templates
     resources :pages, except: [ :destroy ]
@@ -31,6 +35,11 @@ Rails.application.routes.draw do
   # ---------------------------------------------------------------------------
   # Application UI
   # ---------------------------------------------------------------------------
+
+  # Outside :admin by necessity: impersonating drops admin?, which locks the
+  # admin out of /admin, so the exit has to be reachable without it.
+  resource :impersonation, only: [ :destroy ]
+
   resources :scribe_sessions, only: [ :index, :show ] do
     # One part of the consultation's recording, streamed behind the same policy
     # as the page that plays it. A session's audio is either one stored blob or

--- a/test/controllers/impersonations_controller_test.rb
+++ b/test/controllers/impersonations_controller_test.rb
@@ -1,0 +1,216 @@
+require "test_helper"
+
+# Admin "view as user". The properties worth pinning down are the ones that are
+# invisible when they break: that /admin really closes, that writes really are
+# refused, and that the admin can always get back out.
+class ImpersonationsControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    @admin = create(:user)
+    @admin.update!(admin: true, email: "admin@example.com")
+
+    @target = create(:user)
+    @target.update!(email: "clinician@example.com")
+    @target_account = @target.account
+    @target_account.update!(name: "Riverside Clinic")
+  end
+
+  def start_impersonating(user = @target)
+    post impersonate_admin_user_path(user)
+  end
+
+  # ------------------------------------------------------------- who may start
+
+  test "signed-out visitor cannot start an impersonation" do
+    start_impersonating
+    assert_redirected_to new_user_session_path
+  end
+
+  test "non-admin cannot start an impersonation" do
+    sign_in @target
+    other = create(:user)
+    post impersonate_admin_user_path(other)
+    assert_redirected_to root_path
+    follow_redirect!
+    # Still themselves, not the user they aimed at.
+    assert_match @target.account.name, response.body
+  end
+
+  test "admin cannot impersonate another admin" do
+    second_admin = create(:user)
+    second_admin.update!(admin: true, email: "other-admin@example.com")
+
+    sign_in @admin
+    post impersonate_admin_user_path(second_admin)
+
+    assert_redirected_to admin_user_path(second_admin)
+    assert_equal "Cannot view as another admin.", flash[:alert]
+
+    # And no impersonation was started: /admin is still reachable.
+    get admin_users_path
+    assert_response :success
+  end
+
+  # ------------------------------------------------------------ the entry point
+
+  # The show override renders Administrate's own template rather than a copy of
+  # it, so this guards both halves: that the button appears, and that the stock
+  # page still renders around it.
+  test "admin user page offers the button and still renders the resource" do
+    sign_in @admin
+    get admin_user_path(@target)
+
+    assert_response :success
+    assert_match "View as user", response.body
+    assert_match impersonate_admin_user_path(@target), response.body
+    assert_match "clinician@example.com", response.body
+  end
+
+  test "admin user page hides the button for another admin" do
+    second_admin = create(:user)
+    second_admin.update!(admin: true, email: "other-admin@example.com")
+
+    sign_in @admin
+    get admin_user_path(second_admin)
+
+    assert_response :success
+    assert_no_match "View as user", response.body
+  end
+
+  # ------------------------------------------------------------- the happy path
+
+  test "admin starts impersonating and sees the target's account" do
+    sign_in @admin
+    start_impersonating
+
+    assert_redirected_to root_path
+    assert_equal "Now viewing as clinician@example.com.", flash[:notice]
+
+    get account_path
+    assert_response :success
+    assert_match "Riverside Clinic", response.body
+  end
+
+  test "banner names both identities while impersonating" do
+    sign_in @admin
+    start_impersonating
+
+    get root_path
+    assert_response :success
+    assert_match "clinician@example.com", response.body
+    assert_match "admin@example.com", response.body
+  end
+
+  test "no banner when not impersonating" do
+    sign_in @target
+    get root_path
+    assert_response :success
+    assert_no_match(/Stop viewing as user/, response.body)
+  end
+
+  # The exit control sits under a fixed z-50 flash toast by default, which hid
+  # it exactly when a read-only refusal fired. The banner outranks the flash and
+  # the flash drops below it; both have to hold or the safety valve is covered.
+  test "banner outranks the flash and the flash steps aside for it" do
+    sign_in @admin
+    start_impersonating
+
+    get root_path
+    assert_match "sticky top-0 z-[60]", response.body
+    assert_match 'id="flash" class="fixed top-16', response.body
+  end
+
+  test "flash sits at its normal offset when not impersonating" do
+    sign_in @target
+    get root_path
+    assert_match 'id="flash" class="fixed top-4', response.body
+  end
+
+  # --------------------------------------------------------- powers are dropped
+
+  test "admin namespace closes while impersonating" do
+    sign_in @admin
+    get admin_users_path
+    assert_response :success, "precondition: admin can reach /admin"
+
+    start_impersonating
+    get admin_users_path
+
+    assert_redirected_to root_path
+    assert_equal "Not authorized.", flash[:alert]
+  end
+
+  # ------------------------------------------------------------- read-only rule
+
+  test "writes are refused while impersonating" do
+    sign_in @admin
+    start_impersonating
+
+    patch account_path, params: { account: { name: "Renamed By Admin" } }
+
+    assert_redirected_to root_path
+    assert_match(/read-only/, flash[:alert])
+    assert_equal "Riverside Clinic", @target_account.reload.name
+  end
+
+  test "reads are unaffected while impersonating" do
+    sign_in @admin
+    start_impersonating
+
+    get account_path
+    assert_response :success
+  end
+
+  test "the same write succeeds once impersonation has stopped" do
+    sign_in @target
+    patch account_path, params: { account: { name: "Renamed By Owner" } }
+    assert_equal "Renamed By Owner", @target_account.reload.name
+  end
+
+  # ----------------------------------------------------------------- getting out
+
+  test "stopping restores the admin and returns them to the user's admin page" do
+    sign_in @admin
+    start_impersonating
+
+    delete impersonation_path
+
+    assert_redirected_to admin_user_path(@target)
+    assert_equal "Stopped viewing as clinician@example.com.", flash[:notice]
+
+    # Powers are back.
+    get admin_users_path
+    assert_response :success
+  end
+
+  # The exit must not sit behind the read-only guard or the admin-only gate,
+  # or it becomes unreachable exactly when it is needed.
+  test "the exit is reachable despite being a write and despite /admin being closed" do
+    sign_in @admin
+    start_impersonating
+
+    get admin_users_path
+    assert_redirected_to root_path, "precondition: /admin is closed"
+
+    delete impersonation_path
+    assert_redirected_to admin_user_path(@target)
+  end
+
+  test "stopping when not impersonating is a harmless no-op" do
+    sign_in @admin
+    delete impersonation_path
+    assert_redirected_to root_path
+  end
+
+  # pretender re-checks the real login each request, so a logout cannot leave a
+  # dangling impersonated session behind.
+  test "signing out ends the impersonation" do
+    sign_in @admin
+    start_impersonating
+    sign_out @admin
+
+    get account_path
+    assert_redirected_to new_user_session_path
+  end
+end


### PR DESCRIPTION
Support needs to see what a customer sees. This adds a **View as user** button on the Administrate user page that swaps the viewer into that user's session, and a banner with the way back out.


## Read-only by design

`current_user` becomes the target, so `admin?` goes false and `/admin` closes for the duration. A single verb check refuses every non-GET request.

Enforcing it there rather than in the policies means there is no per-policy rule to forget on the next feature — and no policy had to change.

## Why pretender rather than a hand-rolled session swap

It overrides `current_user` instead of re-signing anyone in, so the admin's real login is never destroyed. Stopping is one session-key delete.

The alternative (`bypass_sign_in`) destroys and replaces the admin's session, which means a lost impersonator reference strands the admin as a user they cannot escape — `/admin` is closed to them by then, so clearing cookies is the only recovery. Pretender also re-checks the real login on every request, so a logout mid-impersonation can't leave a dangling impersonated session.

80 LOC, MIT, no runtime deps beyond ActiveSupport.

## Four things worth a reviewer's eye

- **`impersonates :user` is declared twice** — in `ApplicationController` *and* `Admin::ApplicationController`. Administrate's base class descends from `ActionController::Base`, not from ours, so it inherits no override. Declaring it once leaves `/admin` seeing the real admin and standing wide open mid-impersonation. That is the one failure here that looks like it worked.
- **Stopping lives at a top-level `DELETE /impersonation`, not under `/admin`**, which is closed to the very person who needs the exit. It skips both the read-only guard (it is itself a write) and `verify_authorized` (it acts only on the requester's own session).
- **Impersonating another admin is refused.** Privileges follow the impersonated identity, so it would hand straight back the powers this drops, and with them the ability to write.
- **The banner outranks the flash toast**, which offsets downward to match. The toast is `fixed z-50` and was covering the exit control exactly when a read-only refusal fired — found while verifying in a browser, fixed here, pinned by tests.

## No audit table yet

By decision. The read-only constraint is what makes that defensible: the exposure is viewing, not acting. Start and stop are single call sites, so a log drops in later without touching anything else.

## Verification

Browser, end to end: button renders and the stock Administrate page renders around it → banner appears and the app switches to the target's account → `/admin` returns "Not authorized" → renaming the account is refused, field reverts, DB unchanged → stop returns to the admin page with powers restored.

18 new tests covering the auth gate, the admin-to-admin refusal, `/admin` closing, writes refused, the exit being reachable despite being a write, logout ending the impersonation, and the banner/flash layering.

679 runs, 0 failures. Rubocop clean. Brakeman 0 warnings.

## Unrelated bug found while verifying

Administrate pages raise `NameError: uninitialized constant Administrate::Field::Number` after any dev code reload — `touch app/models/user.rb` reproduces it on files this PR never touches, and a server restart clears it. Pre-existing, development-only (test and production eager-load), and not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Administrators can view the application as a non-admin user.
  * A persistent banner identifies the impersonated user and provides an option to exit.
  * Impersonation sessions are read-only to prevent changes while viewing as another user.
  * Administrators cannot impersonate other administrators.

* **Bug Fixes**
  * Exiting impersonation safely returns administrators to their account page and restores the original session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->