### PR TITLE
Trim impersonation comments to the non-obvious why

### DIFF
--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -6,18 +6,14 @@
 # you're free to overwrite the RESTful controller actions.
 module Admin
   class ApplicationController < Administrate::ApplicationController
-    # Repeated from ::ApplicationController on purpose: Administrate's base
-    # class descends from ActionController::Base, so this namespace inherits
-    # none of the app's overrides. Without it, current_user here would stay the
-    # real admin and /admin would remain open during an impersonation — the one
-    # failure that would look like it worked.
+    # Required here too: this namespace inherits nothing from
+    # ::ApplicationController, so without it /admin stays open mid-impersonation.
     impersonates :user
 
     before_action :authenticate_admin
 
-    # authenticate_user! is Warden's and still sees the real admin (pretender
-    # never touches the session), so the admin stays logged in; it is admin?
-    # going false on the impersonated current_user that closes this namespace.
+    # Warden still sees the real admin; it is admin? going false on the
+    # impersonated current_user that closes this namespace.
     def authenticate_admin
       authenticate_user!
       redirect_to root_path, alert: "Not authorized." unless current_user.admin?

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,14 +1,12 @@
 module Admin
   class UsersController < Admin::ApplicationController
-    # Start viewing the app as this user. The redirect leaves /admin because
-    # this request is the last one that still has admin powers — from the next
-    # one on, current_user is the target and authenticate_admin turns us away.
+    # This request is the last one with admin powers; from the next one on,
+    # authenticate_admin turns us away.
     def impersonate
       target = User.find(params[:id])
 
-      # Privileges follow the impersonated identity, so impersonating another
-      # admin would hand straight back the powers this feature exists to drop —
-      # and with them the ability to write, defeating the read-only guard.
+      # Privileges follow the impersonated identity, so this would hand back
+      # the powers the feature exists to drop.
       if target.admin?
         return redirect_to admin_user_path(target),
                            alert: "Cannot view as another admin."

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,15 +7,9 @@ class ApplicationController < ActionController::Base
   # maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
 
-  # Admin "view as user". current_user becomes the impersonated user, so every
-  # tenant-scoped surface follows without changes: current_account and
-  # pundit_user below already hang off it, and User#admin? goes false, which is
-  # what closes /admin for the duration.
-  #
-  # This is declared again in Admin::ApplicationController — Administrate's base
-  # class descends from ActionController::Base, NOT from this class, so it does
-  # not inherit the override. Without both, /admin would keep seeing the real
-  # admin and stay open mid-impersonation.
+  # Declared again in Admin::ApplicationController: Administrate's base class
+  # descends from ActionController::Base, so it inherits nothing from here and
+  # /admin would stay open mid-impersonation.
   impersonates :user
 
   # The UI is private by default: every controller requires a signed-in user
@@ -40,8 +34,8 @@ class ApplicationController < ActionController::Base
     current_user
   end
 
-  # Compared against true_user rather than reading pretender's session key, so
-  # this keeps working if the gem renames it.
+  # Compared against true_user rather than pretender's session key, which is
+  # internal to the gem.
   def impersonating?
     current_user.present? && current_user != true_user
   end
@@ -49,11 +43,8 @@ class ApplicationController < ActionController::Base
 
   private
 
-  # Impersonation is a viewing tool: the admin sees the tenant's data but never
-  # acts as them. A blanket verb check is the whole enforcement — policies stay
-  # untouched, so there is no per-policy rule to remember on the next feature.
-  # Anything that legitimately writes while impersonating (only the exit route
-  # today) skips this callback explicitly.
+  # A blanket verb check rather than per-policy rules, so there is nothing to
+  # remember on the next feature. Legitimate writes skip this callback.
   def enforce_read_only_while_impersonating
     return unless impersonating?
     return if request.get? || request.head?

--- a/app/controllers/impersonations_controller.rb
+++ b/app/controllers/impersonations_controller.rb
@@ -1,13 +1,8 @@
-# Ending an impersonation. Deliberately NOT under /admin: admin? is false for
-# the duration, so that namespace is closed to the very person who needs to get
-# out of it. This is the one door that has to stay on the outside.
+# Outside /admin by necessity: admin? is false while impersonating, so that
+# namespace is closed to the person who needs the exit.
 class ImpersonationsController < ApplicationController
-  # DELETE is a write, and the read-only guard blocks writes while
-  # impersonating — which would make the exit unreachable.
+  # The exit is itself a write, and acts only on the requester's own session.
   skip_before_action :enforce_read_only_while_impersonating
-
-  # There is no record to authorize here: the action's whole effect is on the
-  # requester's own session, and the guard below is the authorization.
   skip_after_action :verify_authorized
 
   def destroy
@@ -15,7 +10,6 @@ class ImpersonationsController < ApplicationController
 
     was = current_user
     stop_impersonating_user
-    # Back to where the admin started, rather than to a generic admin root.
     redirect_to admin_user_path(was), notice: "Stopped viewing as #{was.email}."
   end
 end

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,10 +1,5 @@
-<%#
-Adds a "View as user" button to Administrate's stock show page.
-
-Rendering the gem's own template rather than copying it keeps this to the one
-thing we're adding — :header_last is the hook it provides for exactly this.
-%>
-
+<%# Renders Administrate's own template rather than a copy of it; :header_last
+    is the hook it provides for adding an action. %>
 <% unless page.resource.admin? %>
   <% content_for(:header_last) do %>
     <%= button_to "View as user",

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -1,5 +1,4 @@
-<%# Drops below the impersonation banner when one is showing, so the toast and
-    the "stop viewing as user" control never cover each other. %>
+<%# Drops below the impersonation banner so the toast never covers its exit. %>
 <div id="flash" class="fixed <%= impersonating? ? "top-16" : "top-4" %> right-4 z-50 max-w-md" data-controller="flash">
   <% if notice %>
     <div class="notice bg-blue-100 border-l-4 border-blue-500 text-blue-700 p-4 mb-4 rounded shadow-md" role="alert">

--- a/app/views/shared/_impersonation_banner.html.erb
+++ b/app/views/shared/_impersonation_banner.html.erb
@@ -1,9 +1,6 @@
-<%# Persistent while impersonating: the whole point is that the admin can never
-    forget whose data is on screen, so this sits above the nav on every page. %>
 <% if impersonating? %>
-  <%# Sticky and above the flash's z-50: the exit is the safety valve, so it
-      must stay reachable without scrolling and must never be painted over.
-      The flash offsets itself downward to match — see shared/_flash. %>
+  <%# Above the flash's z-50 so the exit is never painted over; the flash
+      offsets down to match (see shared/_flash). %>
   <div class="bg-amber-500 text-amber-950 sticky top-0 z-[60]" role="status">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-2 flex flex-wrap items-center justify-between gap-2">
       <p class="text-sm font-medium">

--- a/test/controllers/impersonations_controller_test.rb
+++ b/test/controllers/impersonations_controller_test.rb
@@ -1,8 +1,7 @@
 require "test_helper"
 
-# Admin "view as user". The properties worth pinning down are the ones that are
-# invisible when they break: that /admin really closes, that writes really are
-# refused, and that the admin can always get back out.
+# The properties that are invisible when they break: /admin really closes,
+# writes are really refused, and the admin can always get back out.
 class ImpersonationsControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
@@ -54,9 +53,8 @@ class ImpersonationsControllerTest < ActionDispatch::IntegrationTest
 
   # ------------------------------------------------------------ the entry point
 
-  # The show override renders Administrate's own template rather than a copy of
-  # it, so this guards both halves: that the button appears, and that the stock
-  # page still renders around it.
+  # Guards both halves of the show override: the button, and the stock page
+  # still rendering around it.
   test "admin user page offers the button and still renders the resource" do
     sign_in @admin
     get admin_user_path(@target)
@@ -109,9 +107,7 @@ class ImpersonationsControllerTest < ActionDispatch::IntegrationTest
     assert_no_match(/Stop viewing as user/, response.body)
   end
 
-  # The exit control sits under a fixed z-50 flash toast by default, which hid
-  # it exactly when a read-only refusal fired. The banner outranks the flash and
-  # the flash drops below it; both have to hold or the safety valve is covered.
+  # The fixed z-50 flash hid the exit exactly when a read-only refusal fired.
   test "banner outranks the flash and the flash steps aside for it" do
     sign_in @admin
     start_impersonating
@@ -184,8 +180,7 @@ class ImpersonationsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  # The exit must not sit behind the read-only guard or the admin-only gate,
-  # or it becomes unreachable exactly when it is needed.
+  # The exit must sit behind neither the read-only guard nor the admin gate.
   test "the exit is reachable despite being a write and despite /admin being closed" do
     sign_in @admin
     start_impersonating
@@ -203,8 +198,7 @@ class ImpersonationsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to root_path
   end
 
-  # pretender re-checks the real login each request, so a logout cannot leave a
-  # dangling impersonated session behind.
+  # pretender re-checks the real login each request.
   test "signing out ends the impersonation" do
     sign_in @admin
     start_impersonating


### PR DESCRIPTION
Comments-only follow-up to #87. No behaviour change; 66 lines out, 30 back.

The impersonation feature landed with comments that restated what the code did and enumerated consequences at length. This keeps the non-obvious *why* — the Administrate inheritance trap, why the exit sits outside `/admin`, why the banner outranks the flash — and drops the narration.

679 runs, 0 failures. Rubocop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
